### PR TITLE
Wash and DRY views after toolchain upgrade.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
 
   before_filter :authenticate
+  before_filter :configure_permitted_parameters, if: :devise_controller?
 
   def allowed_preview?
     if params[:filter] == '2013_africa_final' and params[:year] == '2013'
@@ -61,6 +62,10 @@ class ApplicationController < ActionController::Base
   def sql_escape(str)
     conn = ActiveRecord::Base.connection.instance_variable_get("@connection")
     conn.escape(str)
+  end
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.for(:sign_up) { |u| u.permit! }
   end
 
 end

--- a/app/controllers/count_crud.rb
+++ b/app/controllers/count_crud.rb
@@ -15,6 +15,10 @@ module CountCrud
     eval "new_#{level_base_name}_#{level_base_name}_stratum_path(@level)"
   end
 
+  def level_form
+    'layouts/count_crud_form'
+  end
+
   def index
     raise ActiveRecord::RecordNotFound
   end

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -1,5 +1,7 @@
 class ReportController < ApplicationController
 
+  before_filter :set_past_years
+
   def execute(*array)
     sql = ActiveRecord::Base.send(:sanitize_sql_array, array)
     return ActiveRecord::Base.connection.execute(sql)
@@ -13,8 +15,18 @@ class ReportController < ApplicationController
     SQL
   end
 
+  def set_past_years
+    @past_years = ['2007', '2002', '1998', '1995']
+  end
+
   def species
     @species = params[:species].gsub('_',' ')
+    @past_reports = [
+      { year: '2007', authors: 'J.J. Blanc, R.F.W. Barnes, G.C. Craig, H.T. Dublin, C.R. Thouless, I. Douglas-Hamilton, and J.A. Hart' },
+      { year: '2002', authors: 'J.J. Blanc, C.R. Thouless, J.A. Hart, H.T. Dublin, I. Douglas-Hamilton, G.C. Craig and R.F.W. Barnes' },
+      { year: '1998', authors: 'R.F.W. Barnes, G.C. Craig, H.T. Dublin, G. Overton, W. Simons and C.R. Thouless' },
+      { year: '1995', authors: 'M.Y. Said, R.N. Chunge, G.C. Craig, C.R. Thouless, R.F.W. Barnes and H.T. Dublin' }
+    ]
   end
 
   def year

--- a/app/controllers/stratum_crud.rb
+++ b/app/controllers/stratum_crud.rb
@@ -10,6 +10,10 @@ module StratumCrud
     eval "@level.#{@level.count_base_name} = @level.count_class.find(id_param)"
   end
 
+  def level_display
+    nil
+  end
+
   def index
     raise ActiveRecord::RecordNotFound
   end

--- a/app/controllers/survey_crud.rb
+++ b/app/controllers/survey_crud.rb
@@ -12,6 +12,10 @@
 
 module SurveyCrud
 
+  def set_title
+    @title = I18n.t 'title', scope: "#{level_base_name.pluralize}.#{params[:action]}"
+  end
+
   def edit_allowed
     if current_user.nil?
       return false
@@ -46,6 +50,14 @@ module SurveyCrud
     eval "#{level_class_name}"
   end
 
+  def level_form
+    'layouts/survey_crud_form'
+  end
+
+  def level_display
+    'layouts/survey_display'
+  end
+
   # this allows the use of the Rails convention of a specifically
   # named class variable in views, e.g. @survey_aerial_transect_count,
   # but just @level will do fine, and is preferred going forward
@@ -55,25 +67,31 @@ module SurveyCrud
   end
 
   def index
+    set_title
     @levels = level_class.all
   end
 
   def show
+    set_title
     @level = level_class.find(params[:id])
     find_parents @level
     enable_named_class_variable
+    render template: level_display if level_display
   end
 
   def new
+    set_title
     @level = level_class.new
     if respond_to? 'connect_parent'
       connect_parent
       find_parents @level
     end
     enable_named_class_variable
+    render template: level_form if level_form
   end
 
   def edit
+    set_title
     @level = level_class.find(params[:id])
     find_parents @level
     enable_named_class_variable
@@ -86,6 +104,7 @@ module SurveyCrud
       redirect_to @level
       return
     end
+    render template: level_form if level_form
   end
 
   def create

--- a/app/controllers/survey_individual_registrations_controller.rb
+++ b/app/controllers/survey_individual_registrations_controller.rb
@@ -6,4 +6,12 @@ class SurveyIndividualRegistrationsController < ApplicationController
     @level
   end
 
+  def level_form
+    'layouts/survey_crud_form'
+  end
+
+  def level_display
+    nil
+  end
+
 end

--- a/app/controllers/survey_others_controller.rb
+++ b/app/controllers/survey_others_controller.rb
@@ -6,4 +6,12 @@ class SurveyOthersController < ApplicationController
     @level
   end
 
+  def level_display
+    nil
+  end
+
+  def level_form
+    'layouts/survey_crud_form'
+  end
+
 end

--- a/app/views/about/darp.html.slim
+++ b/app/views/about/darp.html.slim
@@ -1,206 +1,208 @@
-h1 Data Access and Release Policy of the African Elephant Database
-.wiki
+.row
+  .col-xs-12
+    h1 Data Access and Release Policy of the African Elephant Database
+    .wiki
 
-  h2
-    | Introduction
-  p
-    | The African Elephant Database (AED) of the IUCN/SSC African Elephant
-    | Specialist Group (AfESG) aims to provide an accurate and objective
-    | continent-wide picture on the status and distribution of the African
-    | elephant, and thus help in developing long-term management and
-    | conservation strategies for the species. Data entered into the African
-    | Elephant Database are obtained through the generous assistance of many
-    | governments, organizations and individuals from numerous elephant
-    | Range States throughout sub-Saharan Africa.
-  p
-    | The African Elephant Database comprises a number of distinct components:
-  ul
-    li
-      | A set of electronic maps of areas where information on elephant
-      | numbers has been collected throughout the years. These maps are
-      | linked to database tables giving information on the types and
-      | results of surveys, reliability, and other relevant factors.
-    li
-      | A set of electronic maps depicting elephant distribution. Some of
-      | the areas depicted in the distribution maps have been formally
-      | surveyed, whereas others have not. Distribution maps are linked
-      | to database tables which give additional information about the
-      | nature and reliability of range information.
-    li
-      | Additional electronic maps depicting ancillary information, such
-      | as protected areas, national boundaries, roads, rivers and relief.
-      | Most of these ancillary maps have been obtained from third-party
-      | providers and do not belong to the AfESG.
-    li
-      | Supporting documentation for the electronic database.
-    li
-      | Data in the AED are subject to extensive review by the Data Review
-      | Working Group (DRWG) of the AfESG. In addition, digitized data
-      | undergo stringent validation and verification procedures as they
-      | are entered into the AED. These processes lead to the preparation
-      | and publication of periodic “status reports,” which summarize
-      | verified information in the full database and which aim to
-      | provide the best interpretation of available data.
-    li
-      | At any time between the publication of status reports, the
-      | electronic version of the AED is a 'work in progress' and may
-      | therefore include contradictory and/or unverified information.
-  h2
-    | Objectives and General Policy Statement
-  p
-    | The primary objective of this policy is to make the AED as freely and
-    | widely available as possible, while encouraging users of AED data to
-    | take account of the limitations of the data in their analyses. It is
-    | also the duty of AfESG, and an objective of this policy, to ensure that:
-  ul
-    li
-      | AED data are used for the benefit of elephant conservation in Africa.
-    li
-      | The wishes of providers of source information who have placed express
-      | restrictions on the dissemination of their raw data are respected.
-    li
-      | Any agreements with providers of ancillary GIS information are respected.
-    li
-      | The integrity of the database is maintained by discouraging the
-      | circulation of multiple modified versions.
-    li
-      | It is the belief of the AfESG that the above objectives can best be
-      | achieved with the following broad policies:
+      h2
+        | Introduction
+      p
+        | The African Elephant Database (AED) of the IUCN/SSC African Elephant
+        | Specialist Group (AfESG) aims to provide an accurate and objective
+        | continent-wide picture on the status and distribution of the African
+        | elephant, and thus help in developing long-term management and
+        | conservation strategies for the species. Data entered into the African
+        | Elephant Database are obtained through the generous assistance of many
+        | governments, organizations and individuals from numerous elephant
+        | Range States throughout sub-Saharan Africa.
+      p
+        | The African Elephant Database comprises a number of distinct components:
       ul
         li
-          | Hard copy and 'read-only' electronic versions of the AED are freely
-          | available: electronic Status Report can be downloaded from the
-          | Internet, and the printed version is available on request, subject
-          | to logistic and financial constraints.
+          | A set of electronic maps of areas where information on elephant
+          | numbers has been collected throughout the years. These maps are
+          | linked to database tables giving information on the types and
+          | results of surveys, reliability, and other relevant factors.
         li
-          | Full or partial, editable versions of the updated electronic
-          | database will be made available on a controlled basis, with
-          | conditions designed to restrict the dissemination of altered
-          | versions and of ancillary data layers that are not the property
-          | of AfESG, and to encourage people analyzing the data to take
-          | account of its limitations.
+          | A set of electronic maps depicting elephant distribution. Some of
+          | the areas depicted in the distribution maps have been formally
+          | surveyed, whereas others have not. Distribution maps are linked
+          | to database tables which give additional information about the
+          | nature and reliability of range information.
         li
-          | Unless Data Providers have placed restrictions on the circulation
-          | of source data, such data will be made available for inspection
-          | upon request, subject to logistic and financial constraints.
-    li
-      | The above points are for guidance only. The details of this policy
-      | are set out in the two sections that follow.
-  h2
-    | Definitions
-  p
-    | For the purposes of this policy, the following definitions shall apply:
-  ul
-    li
-      | <i>African Elephant Database (AED)</i> - An electronic collection of tables,
-      | georeferenced maps and any other datasets, digitized by the African
-      | Elephant Specialist Group and containing information relating to
-      | elephant distribution and abundance in the Range States of African
-      | Elephants. Any data captured or digitized and integrated into the African
-      | Elephant Database and any views or extracts thereof remain the property
-      | of the African Elephant Specialist Group.
-    li
-      | <i>African Elephant Database Source Data</i> – The collection of reports,
-      | personal communications, questionnaire replies, publications and any
-      | other form of data or information submitted to the AfESG for input
-      | into the African Elephant Database.
-    li
-      | <i>African Elephant Status Report (AESR)</i> – Any of the reports on the
-      | status and distribution of African elephants produced by the IUCN/SSC
-      | African Elephant Specialist Group (generally every three years) in hard
-      | copy and/or read-only electronic format. African Elephant Status
-      | Reports, which have been in the past published under the name “African
-      | Elephant Database”, contain views from the African Elephant Database.
-    li
-      | <i>Ancillary Datasets</i> – A collection of tables and maps in digital format
-      | and views and extracts thereof produced by third parties and employed
-      | in the African Elephant Database.
-    li
-      | <i>Digital Data Extract</i> – A digital subset data contained in the African
-      | Elephant Database and/or related digital databases operated by the
-      | African Elephant Specialist Group in editable, tabular or graphic,
-      | geo-referenced format.
-    li
-      | <i>View</i> – A snapshot of a subset of data contained in the African
-      | Elephant Database and/or related digital databases operated by the
-      | African Elephant Specialist Group, in a non-georeferenced, rasterized
-      | or non-editable electronic vector format, or in hard copy.
-  h2
-    | Access to Data from the African Elephant Database
-  p
-    | Digital data will be made available to African Elephant Specialist Group
-    | (AfESG) members on request, and may be made available to other groups or
-    | individuals provided the conditions detailed below are satisfied.
-  ol
-    li
-      | <i>Access to AED Status Reports.</i
-      | For the purpose of data release and access, AED Status Reports and any
-      | data views contained therein are in the public domain once they have
-      | been published in hard copy or released in read-only electronic format
-      | on the official AfESG Internet web site. Access to AED Status Reports
-      | is subject to availability. Dissemination of altered hard copy or
-      | electronic AED Status Reports by third parties is not permitted.
-    li
-      | <i>Access to Views from the African Elephant Database.</i
-      | Views of the database depicting processed summary tables or maps in
-      | non geo-referenced, bitmapped or non-editable vector graphic formats
-      | may be made available upon written request, subject to resource constraints.
-    li
-      | <i>Access to Digital Data Extracts from the African Elephant Database.</i
-      | The release of digital Data Extracts from the African Elephant Database
-      | is subject to the following conditions:
-    ol
-      li
-        | Any person(s) or group(s) wishing to obtain digital data extracts
-        | from the AED must submit a proposal to the AfESG Data Review Working
-        | Group (DRWG), outlining how the database is to be used and why the
-        | data are required in digital form. Digital data will be released if
-        | the DRWG considers the release not to violate existing agreements with
-        | data providers, the intended use is not anticipated to be detrimental
-        | to elephant conservation and takes account of the limitations of
-        | data quality.
-      li
-        | The authors, prior to submission, publication or dissemination of
-        | any output containing any views, alterations, manipulations or
-        | analysis of digital data extracted from the African Elephant Database,
-        | must submit to the DRWG, for review and comment, a final draft of all
-        | materials intended for dissemination.
-      li
-        | Any alteration to digital data supplied by the AED and intended
-        | for publication, dissemination or placement in the public domain,
-        | must be accompanied by a statement by the author(s), clearly
-        | describing the nature of any alterations effected on data extracted
-        | from the African Elephant Database. The author(s) must also submit
-        | to the Data Review Working Group the altered dataset in its entirety
-        | for review, and grant express permission to the AfESG for possible
-        | integration of the altered data into the African Elephant Database,
-        | subject to review and acceptance by the DRWG.
-      li
-        | Digital Data Extracts released to any person or group will
-        | remain the property of the AfESG and will not be passed on to any
-        | third party
-      li
-        | Any AED data used in papers, reports, publications or any other
-        | output will be given proper acknowledgement, which will be stipulated
-        | in the users agreement (see number 7).
-      li
-        | The AfESG secretariat must be provided with 2 copies of any
-        | document or output in which data from the AED is used.
-      li
-        | An agreement to the standard terms and conditions above must be
-        | signed and returned to the AfESG Secretariat before any data will be
-        | released. Such an agreement will include points 2, 3, 4, 5 and 6
-        | listed above.
-    li
-      | <i>Access to Source Data.</i> As a custodian of AED Source Data,
-      | the AfESG has no rights of ownership or any obligations to their
-      | dissemination, but unless specifically restricted by the Data
-      | Provider, will allow their inspection. Any other conditions imposed
-      | by the Data Providers on the release of Source Data, views or extracts
-      | thereof will be observed.
-    li
-      | <i>Access to Ancillary Datasets</i> As an end user of Ancillary Datasets,
-      | the AfESG may have no rights to their dissemination, and where
-      | permitted, their release will be subject to any conditions imposed by
-      | the Data Provider. In all other cases the AfESG will re-direct any
-      | requests for such datasets to the appropriate data provider.
+          | Additional electronic maps depicting ancillary information, such
+          | as protected areas, national boundaries, roads, rivers and relief.
+          | Most of these ancillary maps have been obtained from third-party
+          | providers and do not belong to the AfESG.
+        li
+          | Supporting documentation for the electronic database.
+        li
+          | Data in the AED are subject to extensive review by the Data Review
+          | Working Group (DRWG) of the AfESG. In addition, digitized data
+          | undergo stringent validation and verification procedures as they
+          | are entered into the AED. These processes lead to the preparation
+          | and publication of periodic “status reports,” which summarize
+          | verified information in the full database and which aim to
+          | provide the best interpretation of available data.
+        li
+          | At any time between the publication of status reports, the
+          | electronic version of the AED is a 'work in progress' and may
+          | therefore include contradictory and/or unverified information.
+      h2
+        | Objectives and General Policy Statement
+      p
+        | The primary objective of this policy is to make the AED as freely and
+        | widely available as possible, while encouraging users of AED data to
+        | take account of the limitations of the data in their analyses. It is
+        | also the duty of AfESG, and an objective of this policy, to ensure that:
+      ul
+        li
+          | AED data are used for the benefit of elephant conservation in Africa.
+        li
+          | The wishes of providers of source information who have placed express
+          | restrictions on the dissemination of their raw data are respected.
+        li
+          | Any agreements with providers of ancillary GIS information are respected.
+        li
+          | The integrity of the database is maintained by discouraging the
+          | circulation of multiple modified versions.
+        li
+          | It is the belief of the AfESG that the above objectives can best be
+          | achieved with the following broad policies:
+          ul
+            li
+              | Hard copy and 'read-only' electronic versions of the AED are freely
+              | available: electronic Status Report can be downloaded from the
+              | Internet, and the printed version is available on request, subject
+              | to logistic and financial constraints.
+            li
+              | Full or partial, editable versions of the updated electronic
+              | database will be made available on a controlled basis, with
+              | conditions designed to restrict the dissemination of altered
+              | versions and of ancillary data layers that are not the property
+              | of AfESG, and to encourage people analyzing the data to take
+              | account of its limitations.
+            li
+              | Unless Data Providers have placed restrictions on the circulation
+              | of source data, such data will be made available for inspection
+              | upon request, subject to logistic and financial constraints.
+        li
+          | The above points are for guidance only. The details of this policy
+          | are set out in the two sections that follow.
+      h2
+        | Definitions
+      p
+        | For the purposes of this policy, the following definitions shall apply:
+      ul
+        li
+          | <i>African Elephant Database (AED)</i> - An electronic collection of tables,
+          | georeferenced maps and any other datasets, digitized by the African
+          | Elephant Specialist Group and containing information relating to
+          | elephant distribution and abundance in the Range States of African
+          | Elephants. Any data captured or digitized and integrated into the African
+          | Elephant Database and any views or extracts thereof remain the property
+          | of the African Elephant Specialist Group.
+        li
+          | <i>African Elephant Database Source Data</i> – The collection of reports,
+          | personal communications, questionnaire replies, publications and any
+          | other form of data or information submitted to the AfESG for input
+          | into the African Elephant Database.
+        li
+          | <i>African Elephant Status Report (AESR)</i> – Any of the reports on the
+          | status and distribution of African elephants produced by the IUCN/SSC
+          | African Elephant Specialist Group (generally every three years) in hard
+          | copy and/or read-only electronic format. African Elephant Status
+          | Reports, which have been in the past published under the name “African
+          | Elephant Database”, contain views from the African Elephant Database.
+        li
+          | <i>Ancillary Datasets</i> – A collection of tables and maps in digital format
+          | and views and extracts thereof produced by third parties and employed
+          | in the African Elephant Database.
+        li
+          | <i>Digital Data Extract</i> – A digital subset data contained in the African
+          | Elephant Database and/or related digital databases operated by the
+          | African Elephant Specialist Group in editable, tabular or graphic,
+          | geo-referenced format.
+        li
+          | <i>View</i> – A snapshot of a subset of data contained in the African
+          | Elephant Database and/or related digital databases operated by the
+          | African Elephant Specialist Group, in a non-georeferenced, rasterized
+          | or non-editable electronic vector format, or in hard copy.
+      h2
+        | Access to Data from the African Elephant Database
+      p
+        | Digital data will be made available to African Elephant Specialist Group
+        | (AfESG) members on request, and may be made available to other groups or
+        | individuals provided the conditions detailed below are satisfied.
+      ol
+        li
+          | <i>Access to AED Status Reports.</i
+          | For the purpose of data release and access, AED Status Reports and any
+          | data views contained therein are in the public domain once they have
+          | been published in hard copy or released in read-only electronic format
+          | on the official AfESG Internet web site. Access to AED Status Reports
+          | is subject to availability. Dissemination of altered hard copy or
+          | electronic AED Status Reports by third parties is not permitted.
+        li
+          | <i>Access to Views from the African Elephant Database.</i
+          | Views of the database depicting processed summary tables or maps in
+          | non geo-referenced, bitmapped or non-editable vector graphic formats
+          | may be made available upon written request, subject to resource constraints.
+        li
+          | <i>Access to Digital Data Extracts from the African Elephant Database.</i
+          | The release of digital Data Extracts from the African Elephant Database
+          | is subject to the following conditions:
+        ol
+          li
+            | Any person(s) or group(s) wishing to obtain digital data extracts
+            | from the AED must submit a proposal to the AfESG Data Review Working
+            | Group (DRWG), outlining how the database is to be used and why the
+            | data are required in digital form. Digital data will be released if
+            | the DRWG considers the release not to violate existing agreements with
+            | data providers, the intended use is not anticipated to be detrimental
+            | to elephant conservation and takes account of the limitations of
+            | data quality.
+          li
+            | The authors, prior to submission, publication or dissemination of
+            | any output containing any views, alterations, manipulations or
+            | analysis of digital data extracted from the African Elephant Database,
+            | must submit to the DRWG, for review and comment, a final draft of all
+            | materials intended for dissemination.
+          li
+            | Any alteration to digital data supplied by the AED and intended
+            | for publication, dissemination or placement in the public domain,
+            | must be accompanied by a statement by the author(s), clearly
+            | describing the nature of any alterations effected on data extracted
+            | from the African Elephant Database. The author(s) must also submit
+            | to the Data Review Working Group the altered dataset in its entirety
+            | for review, and grant express permission to the AfESG for possible
+            | integration of the altered data into the African Elephant Database,
+            | subject to review and acceptance by the DRWG.
+          li
+            | Digital Data Extracts released to any person or group will
+            | remain the property of the AfESG and will not be passed on to any
+            | third party
+          li
+            | Any AED data used in papers, reports, publications or any other
+            | output will be given proper acknowledgement, which will be stipulated
+            | in the users agreement (see number 7).
+          li
+            | The AfESG secretariat must be provided with 2 copies of any
+            | document or output in which data from the AED is used.
+          li
+            | An agreement to the standard terms and conditions above must be
+            | signed and returned to the AfESG Secretariat before any data will be
+            | released. Such an agreement will include points 2, 3, 4, 5 and 6
+            | listed above.
+        li
+          | <i>Access to Source Data.</i> As a custodian of AED Source Data,
+          | the AfESG has no rights of ownership or any obligations to their
+          | dissemination, but unless specifically restricted by the Data
+          | Provider, will allow their inspection. Any other conditions imposed
+          | by the Data Providers on the release of Source Data, views or extracts
+          | thereof will be observed.
+        li
+          | <i>Access to Ancillary Datasets</i> As an end user of Ancillary Datasets,
+          | the AfESG may have no rights to their dissemination, and where
+          | permitted, their release will be subject to any conditions imposed by
+          | the Data Provider. In all other cases the AfESG will re-direct any
+          | requests for such datasets to the appropriate data provider.

--- a/app/views/about/index.html.slim
+++ b/app/views/about/index.html.slim
@@ -1,87 +1,85 @@
+.row
+  .col-xs-12
+    h1 About Elephant Database
+    markdown:
 
-.container
-  .row
-    .col-xs-12
-      h1 About Elephant Database
-      markdown:
+      ElephantDatabase.org is the online home of the African and Asian Elephant Database, a joint project of the
+      IUCN African Elephant Specialist Group (AfESG) and Asian Elephant Specialist Group (AsESG).
 
-        ElephantDatabase.org is the online home of the African and Asian Elephant Database, a joint project of the
-        IUCN African Elephant Specialist Group (AfESG) and Asian Elephant Specialist Group (AsESG).
+      ElephantDatabase.org presents data from past African Elephant Status Reports, as well as the latest
+      survey data reported to either specialist group.  Data on this web site is made available under a
+      [Creative Commons Attribution-NonCommercial-ShareAlike](http://creativecommons.org/licenses/by-nc-sa/3.0/)
+      license.
 
-        ElephantDatabase.org presents data from past African Elephant Status Reports, as well as the latest
-        survey data reported to either specialist group.  Data on this web site is made available under a
-        [Creative Commons Attribution-NonCommercial-ShareAlike](http://creativecommons.org/licenses/by-nc-sa/3.0/)
-        license.
+      Past African Elephant Status Reports, including a large amount of narrative information, are available
+      in PDF format from [the AfESG web site](http://african-elephant.org)
 
-        Past African Elephant Status Reports, including a large amount of narrative information, are available
-        in PDF format from [the AfESG web site](http://african-elephant.org)
+      Getting Involved
+      ----------------
 
-        Getting Involved
-        ----------------
+      ElephantDatabase.org is an Open Source software project.  Every aspect of the database is powered by
+      free and open source software.  We are especially thankful for
+      [PostgreSQL](http://www.postgresql.org"),
+      [PostGIS](http://postgis.refractions.net),
+      and the open source tools that make them possible.
 
-        ElephantDatabase.org is an Open Source software project.  Every aspect of the database is powered by
-        free and open source software.  We are especially thankful for
-        [PostgreSQL](http://www.postgresql.org"),
-        [PostGIS](http://postgis.refractions.net),
-        and the open source tools that make them possible.
+      We also would like to thank [Google Fusion Tables](http://google.com/fusiontables) for serving up
+      simple and free visualizations of our geospatial data.
 
-        We also would like to thank [Google Fusion Tables](http://google.com/fusiontables) for serving up
-        simple and free visualizations of our geospatial data.
+      The African and Asian Elephant Specialist Groups are volunteer organizations, and this site and its
+      software systems are maintained principally by volunteers.  We have an ambitious roadmap, and need
+      your help to continue to grow.  Join us on [Assembla](http://www.assembla.com/spaces/aaed).
 
-        The African and Asian Elephant Specialist Groups are volunteer organizations, and this site and its
-        software systems are maintained principally by volunteers.  We have an ambitious roadmap, and need
-        your help to continue to grow.  Join us on [Assembla](http://www.assembla.com/spaces/aaed).
+      Request Data
+      ----------------
 
-        Request Data
-        ----------------
+      To obtain direct data access to African Elephant data only, please review our
+        [data access and release policy](/about/darp) and
+        complete the [data request form](/data_request_forms/new) online.
 
-        To obtain direct data access to African Elephant data only, please review our
-          [data access and release policy](/about/darp) and
-          complete the [data request form](/data_request_forms/new) online.
+      Thank You
+      ----------------
 
-        Thank You
-        ----------------
+      ElephantDatabase.org would not have been possible without our great donors and partners:
 
-        ElephantDatabase.org would not have been possible without our great donors and partners:
+    .partners
+      = link_to "http://www.iucn.org" do
+        = image_tag "iucn_logo.jpg"
+      = link_to "http://www.iucn.org/about/work/programmes/species/about_ssc/" do
+        = image_tag "ssc2005web_res.gif"
+      = link_to "http://african-elephant.org/" do
+        = image_tag "afesgRGBTxtSml.gif"
+      = link_to "http://www.asesg.org/" do
+        = image_tag "AsESG-logo2.png"
+      br
+      = link_to "http://www.cites.org/eng/prog/MIKE/index.shtml" do
+        = image_tag "cites-logo.jpg"
+      = link_to "http://www.cites.org/eng/prog/MIKE/index.shtml" do
+        = image_tag "logo-mike2.png"
+      = link_to "http://www.solertium.com" do
+        = image_tag "solertium-logo.png"
+      br
+      = link_to "http://www.fws.gov/international/dic/species/species.html" do
+        = image_tag "usfws_logo.png"
+      = link_to "http://ec.europa.eu/environment/cites/home_en.htm" do
+        = image_tag "eu-logo.jpg"
+      = link_to "http://www.tusk.org/" do
+        = image_tag "tusk-logo.png"
+      = link_to "http://www.savetheelephants.org/" do
+        = image_tag "ste-logo.png"
 
-      .partners
-        = link_to "http://www.iucn.org" do
-          = image_tag "iucn_logo.jpg"
-        = link_to "http://www.iucn.org/about/work/programmes/species/about_ssc/" do
-          = image_tag "ssc2005web_res.gif"
-        = link_to "http://african-elephant.org/" do
-          = image_tag "afesgRGBTxtSml.gif"
-        = link_to "http://www.asesg.org/" do
-          = image_tag "AsESG-logo2.png"
-        <br /
-        = link_to "http://www.cites.org/eng/prog/MIKE/index.shtml" do
-          = image_tag "cites-logo.jpg"
-        = link_to "http://www.cites.org/eng/prog/MIKE/index.shtml" do
-          = image_tag "logo-mike2.png"
-        = link_to "http://www.solertium.com" do
-          = image_tag "solertium-logo.png"
-        <br /
-        = link_to "http://www.fws.gov/international/dic/species/species.html" do
-          = image_tag "usfws_logo.png"
-        = link_to "http://ec.europa.eu/environment/cites/home_en.htm" do
-          = image_tag "eu-logo.jpg"
-        = link_to "http://www.tusk.org/" do
-          = image_tag "tusk-logo.png"
-        = link_to "http://www.savetheelephants.org/" do
-          = image_tag "ste-logo.png"
+    markdown:
+      Technology
+      ----------------
 
-      markdown:
-        Technology
-        ----------------
+      ElephantDatabase.org was created with PostgreSQL, PostGIS, Ruby, and Ruby on Rails:
 
-        ElephantDatabase.org was created with PostgreSQL, PostGIS, Ruby, and Ruby on Rails:
-
-      .partners
-        = link_to "http://www.postgresql.org/" do
-          = image_tag "Postgresql_elephant.png"
-        = link_to "http://postgis.refractions.net/" do
-          = image_tag "PostGIS_logo_100h.png"
-        = link_to "http://www.ruby-lang.org/en/" do
-          = image_tag "Ruby_logo.png"
-        = link_to "http://rubyonrails.org/" do
-          = image_tag "Ruby_on_Rails.png"
+    .partners
+      = link_to "http://www.postgresql.org/" do
+        = image_tag "Postgresql_elephant.png"
+      = link_to "http://postgis.refractions.net/" do
+        = image_tag "PostGIS_logo_100h.png"
+      = link_to "http://www.ruby-lang.org/en/" do
+        = image_tag "Ruby_logo.png"
+      = link_to "http://rubyonrails.org/" do
+        = image_tag "Ruby_on_Rails.png"

--- a/app/views/application/_strata_actions.html.slim
+++ b/app/views/application/_strata_actions.html.slim
@@ -1,0 +1,5 @@
+- f = local_assigns[:f]
+
+= f.actions do
+  = f.action :submit, :label => 'Save and enter another stratum'
+  = f.action :submit, :label => 'This is my final stratum'

--- a/app/views/changes/_form.html.slim
+++ b/app/views/changes/_form.html.slim
@@ -7,5 +7,5 @@
     = f.input :replaced_strata
     = f.input :new_strata
     = f.input :reason_change
-  = f.buttons do
-    = f.commit_button
+  = f.actions do
+    = f.submit

--- a/app/views/changes/edit.html.slim
+++ b/app/views/changes/edit.html.slim
@@ -1,5 +1,7 @@
-h1= t '.title'
-p
-  = link_to t('back'), changes_path
-  = link_to t('show'), @change
-= render 'form'
+.row
+  .col-xs-12
+    h1= t '.title'
+    p
+      = link_to t('back'), changes_path
+      = link_to t('show'), @change
+    = render 'form'

--- a/app/views/changes/index.html.slim
+++ b/app/views/changes/index.html.slim
@@ -1,28 +1,30 @@
-h1= t('.title')
-p= link_to t('.new'), new_change_path
+.row
+  .col-xs-12
+    h1= t('.title')
+    p= link_to t('.new'), new_change_path
 
-table
-  thead
-    tr
-      th= Change.human_attribute_name :analysis_name
-      th= Change.human_attribute_name :analysis_year
-      th= Change.human_attribute_name :country
-      th= Change.human_attribute_name :replacement_name
-      th= Change.human_attribute_name :replaced_strata
-      th= Change.human_attribute_name :new_strata
-      th= Change.human_attribute_name :reason_change
-      th colspan=3 = t 'actions'
-  
-  tbody
-    - for change in @changes
-      tr  class=cycle(:odd, :even)  
-        td= change.analysis_name
-        td= change.analysis_year
-        td= change.country
-        td= change.replacement_name
-        td= linked_ids_for change.replaced_strata
-        td= linked_ids_for change.new_strata
-        td= change.reason_change
-        td.action= link_to t('show'), change
-        td.action= link_to t('edit'), edit_change_path(change)
-        td.action= link_to t('destroy'), change, :confirm => t('are_you_sure'), :method => :delete
+    table.table
+      thead
+        tr
+          th= Change.human_attribute_name :analysis_name
+          th= Change.human_attribute_name :analysis_year
+          th= Change.human_attribute_name :country
+          th= Change.human_attribute_name :replacement_name
+          th= Change.human_attribute_name :replaced_strata
+          th= Change.human_attribute_name :new_strata
+          th= Change.human_attribute_name :reason_change
+          th colspan=3 = t 'actions'
+      
+      tbody
+        - for change in @changes
+          tr  class=cycle(:odd, :even)  
+            td= change.analysis_name
+            td= change.analysis_year
+            td= change.country
+            td= change.replacement_name
+            td= linked_ids_for change.replaced_strata
+            td= linked_ids_for change.new_strata
+            td= change.reason_change
+            td.action= link_to t('show'), change
+            td.action= link_to t('edit'), edit_change_path(change)
+            td.action= link_to t('destroy'), change, :confirm => t('are_you_sure'), :method => :delete

--- a/app/views/changes/new.html.slim
+++ b/app/views/changes/new.html.slim
@@ -1,3 +1,5 @@
-h1= t '.title'
-p= link_to t('back'), changes_path
-= render 'form'
+.row
+  .col-xs-12
+    h1= t '.title'
+    p= link_to t('back'), changes_path
+    = render 'form'

--- a/app/views/changes/show.html.slim
+++ b/app/views/changes/show.html.slim
@@ -1,19 +1,21 @@
-h1= t '.title'
-p
-  = link_to t('back'), changes_path
-  = link_to t('edit'), edit_change_path(@change)
-  = link_to t('.new'), new_change_path
+.row
+  .col-xs-12
+    h1= t '.title'
+    p
+      = link_to t('back'), changes_path
+      = link_to t('edit'), edit_change_path(@change)
+      = link_to t('.new'), new_change_path
 
-dl
-  dt= Change.human_attribute_name :analysis_name
-  dd= @change.analysis_name
-  dt= Change.human_attribute_name :analysis_year
-  dd= @change.analysis_year
-  dt= Change.human_attribute_name :replacement_name
-  dd= @change.replacement_name
-  dt= Change.human_attribute_name :replaced_strata
-  dd= @change.replaced_strata
-  dt= Change.human_attribute_name :new_strata
-  dd= @change.new_strata
-  dt= Change.human_attribute_name :reason_change
-  dd= @change.reason_change
+    dl
+      dt= Change.human_attribute_name :analysis_name
+      dd= @change.analysis_name
+      dt= Change.human_attribute_name :analysis_year
+      dd= @change.analysis_year
+      dt= Change.human_attribute_name :replacement_name
+      dd= @change.replacement_name
+      dt= Change.human_attribute_name :replaced_strata
+      dd= @change.replaced_strata
+      dt= Change.human_attribute_name :new_strata
+      dd= @change.new_strata
+      dt= Change.human_attribute_name :reason_change
+      dd= @change.reason_change

--- a/app/views/data_request_forms/_form.html.slim
+++ b/app/views/data_request_forms/_form.html.slim
@@ -19,28 +19,28 @@
     - if @show_status != nil
       = f.input :status, :as => :select, :collection => ['Approved','Denied']
   markdown:
-    | The release of AED digital data is subject to the acceptance of the following conditions:
+    The release of AED digital data is subject to the acceptance of the following conditions:
 
-    | 1.  The authors, prior to submission, publication or dissemination
-        | of any output containing any views, alterations, manipulations
-        | or analysis of digital data extracted from the African Elephant
-        | Database, must submit to the DRWG, for review and comment, a
-        | final draft of all materials intended for dissemination.
-    | 2.  Any alteration to digital data supplied by the AED and intended
-        | for publication, dissemination or placement in the public domain,
-        | must be accompanied by a statement by the author(s), clearly
-        | describing the nature of any alterations effected on data
-        | extracted from the African Elephant Database. The author(s)
-        | must also submit to the Data Review Working Group the altered
-        | dataset in its entirety for review, and grant express permission
-        | to the AfESG for possible integration of the altered data into
-        | the African Elephant Database, should the DRWG so recommend.
-    | 3.  Digital Data Extracts released to any person or group will remain
-        | the property of the AfESG and shall not be passed on to any third party.
-    | 4.  Any AED data used in papers, reports, publications or any other
-        | output will be given proper acknowledgement, as described in the Annex.
-    | 5.  The AfESG secretariat will be provided with 2 copies of any
-        | document or output in which AED data is used.
+    1.  The authors, prior to submission, publication or dissemination
+        of any output containing any views, alterations, manipulations
+        or analysis of digital data extracted from the African Elephant
+        Database, must submit to the DRWG, for review and comment, a
+        final draft of all materials intended for dissemination.
+    2.  Any alteration to digital data supplied by the AED and intended
+        for publication, dissemination or placement in the public domain,
+        must be accompanied by a statement by the author(s), clearly
+        describing the nature of any alterations effected on data
+        extracted from the African Elephant Database. The author(s)
+        must also submit to the Data Review Working Group the altered
+        dataset in its entirety for review, and grant express permission
+        to the AfESG for possible integration of the altered data into
+        the African Elephant Database, should the DRWG so recommend.
+    3.  Digital Data Extracts released to any person or group will remain
+        the property of the AfESG and shall not be passed on to any third party.
+    4.  Any AED data used in papers, reports, publications or any other
+        output will be given proper acknowledgement, as described in the Annex.
+    5.  The AfESG secretariat will be provided with 2 copies of any
+        document or output in which AED data is used.
 
-    | I hereby agree to abide by the above conditions.
-  = f.buttons
+    I hereby agree to abide by the above conditions.
+  = f.actions

--- a/app/views/data_request_forms/edit.html.slim
+++ b/app/views/data_request_forms/edit.html.slim
@@ -1,6 +1,8 @@
-h1= t '.title'
-p
-  = link_to t('back'), data_request_forms_path
-  = link_to t('show'), @data_request_form
-  - @show_status = true
-= render 'form'
+.row
+  .col-xs-12
+    h1= t '.title'
+    p
+      = link_to t('back'), data_request_forms_path
+      = link_to t('show'), @data_request_form
+      - @show_status = true
+    = render 'form'

--- a/app/views/data_request_forms/index.html.slim
+++ b/app/views/data_request_forms/index.html.slim
@@ -1,22 +1,24 @@
-h1= t('.title')
-p= link_to t('.new'), new_data_request_form_path
+.row
+  .col-xs-12
+    h1= t('.title')
+    p= link_to t('.new'), new_data_request_form_path
 
-table
-  thead
-    tr
-      th= DataRequestForm.human_attribute_name :name
-      th= DataRequestForm.human_attribute_name :organization
-      th Status
-      th Date Submitted
-      th colspan=3 = t 'actions'
+    table.table
+      thead
+        tr
+          th= DataRequestForm.human_attribute_name :name
+          th= DataRequestForm.human_attribute_name :organization
+          th Status
+          th Date Submitted
+          th colspan=3 = t 'actions'
 
-  tbody
-    - for data_request_form in @data_request_forms
-      tr  class=cycle(:odd, :even)  
-        td= data_request_form.name
-        td= data_request_form.organization
-        td= data_request_form.status
-        td= data_request_form.created_at
-        td.action= link_to t('show'), data_request_form
-        td.action= link_to t('edit'), edit_data_request_form_path(data_request_form)
-        td.action= link_to t('destroy'), data_request_form, :confirm => t('are_you_sure'), :method => :delete
+      tbody
+        - for data_request_form in @data_request_forms
+          tr  class=cycle(:odd, :even)  
+            td= data_request_form.name
+            td= data_request_form.organization
+            td= data_request_form.status
+            td= data_request_form.created_at
+            td.action= link_to t('show'), data_request_form
+            td.action= link_to t('edit'), edit_data_request_form_path(data_request_form)
+            td.action= link_to t('destroy'), data_request_form, :confirm => t('are_you_sure'), :method => :delete

--- a/app/views/data_request_forms/new.html.slim
+++ b/app/views/data_request_forms/new.html.slim
@@ -1,3 +1,5 @@
-h1= t '.title'
-p= link_to t('back'), data_request_forms_path
-= render 'form'
+.row
+  .col-xs-12
+    h1= t '.title'
+    p= link_to t('back'), data_request_forms_path
+    = render 'form'

--- a/app/views/data_request_forms/show.html.slim
+++ b/app/views/data_request_forms/show.html.slim
@@ -1,38 +1,40 @@
-h1= t '.title'
-p
-  = link_to t('back'), data_request_forms_path
-  = link_to t('edit'), edit_data_request_form_path(@data_request_form)
+.row
+  .col-xs-12
+    h1= t '.title'
+    p
+      = link_to t('back'), data_request_forms_path
+      = link_to t('edit'), edit_data_request_form_path(@data_request_form)
 
-dl
-  dt= DataRequestForm.human_attribute_name :name
-  dd= @data_request_form.name
-  dt= DataRequestForm.human_attribute_name :title
-  dd= @data_request_form.title
-  dt= DataRequestForm.human_attribute_name :department
-  dd= @data_request_form.department
-  dt= DataRequestForm.human_attribute_name :organization
-  dd= @data_request_form.organization
-  dt= DataRequestForm.human_attribute_name :telephone
-  dd= @data_request_form.telephone
-  dt= DataRequestForm.human_attribute_name :fax
-  dd= @data_request_form.fax
-  dt= DataRequestForm.human_attribute_name :email
-  dd= @data_request_form.email
-  dt= DataRequestForm.human_attribute_name :website
-  dd= @data_request_form.website
-  dt= DataRequestForm.human_attribute_name :address
-  dd= @data_request_form.address
-  dt= DataRequestForm.human_attribute_name :town
-  dd= @data_request_form.town
-  dt= DataRequestForm.human_attribute_name :post_code
-  dd= @data_request_form.post_code
-  dt= DataRequestForm.human_attribute_name :state
-  dd= @data_request_form.state
-  dt= DataRequestForm.human_attribute_name :country
-  dd= @data_request_form.country
-  dt= DataRequestForm.human_attribute_name :extracts
-  dd= @data_request_form.extracts
-  dt= DataRequestForm.human_attribute_name :research
-  dd= @data_request_form.research
-  dt Date Submitted
-  dd= @data_request_form.created_at
+    dl
+      dt= DataRequestForm.human_attribute_name :name
+      dd= @data_request_form.name
+      dt= DataRequestForm.human_attribute_name :title
+      dd= @data_request_form.title
+      dt= DataRequestForm.human_attribute_name :department
+      dd= @data_request_form.department
+      dt= DataRequestForm.human_attribute_name :organization
+      dd= @data_request_form.organization
+      dt= DataRequestForm.human_attribute_name :telephone
+      dd= @data_request_form.telephone
+      dt= DataRequestForm.human_attribute_name :fax
+      dd= @data_request_form.fax
+      dt= DataRequestForm.human_attribute_name :email
+      dd= @data_request_form.email
+      dt= DataRequestForm.human_attribute_name :website
+      dd= @data_request_form.website
+      dt= DataRequestForm.human_attribute_name :address
+      dd= @data_request_form.address
+      dt= DataRequestForm.human_attribute_name :town
+      dd= @data_request_form.town
+      dt= DataRequestForm.human_attribute_name :post_code
+      dd= @data_request_form.post_code
+      dt= DataRequestForm.human_attribute_name :state
+      dd= @data_request_form.state
+      dt= DataRequestForm.human_attribute_name :country
+      dd= @data_request_form.country
+      dt= DataRequestForm.human_attribute_name :extracts
+      dd= @data_request_form.extracts
+      dt= DataRequestForm.human_attribute_name :research
+      dd= @data_request_form.research
+      dt Date Submitted
+      dd= @data_request_form.created_at

--- a/app/views/devise/confirmations/new.html.slim
+++ b/app/views/devise/confirmations/new.html.slim
@@ -1,9 +1,11 @@
-h2 Resend confirmation instructions
-= semantic_form_for resource, :as => resource_name, :url => confirmation_path(resource_name), :html => { :method => :post } do |f|
-  = devise_error_messages!
-  = f.inputs do
-    = f.input :email
-  = f.buttons do
-    = f.commit_button :resend_confirmation_instructions
-= render :partial => "devise/shared/links"
-/!/  %p= f.submit "Resend confirmation instructions"
+.row
+  .col-xs-12
+    h2 Resend confirmation instructions
+    = semantic_form_for resource, :as => resource_name, :url => confirmation_path(resource_name), :html => { :method => :post } do |f|
+      = devise_error_messages!
+      = f.inputs do
+        = f.input :email
+      = f.actions do
+        = f.action :submit, label: :resend_confirmation_instructions
+    = render :partial => "devise/shared/links"
+    /!/  %p= f.submit "Resend confirmation instructions"

--- a/app/views/devise/mailer/confirmation_instructions.html.slim
+++ b/app/views/devise/mailer/confirmation_instructions.html.slim
@@ -1,4 +1,4 @@
 p
   | Welcome #{@resource.email}!
 p You can confirm your account through the link below:
-p= link_to 'Confirm my account', confirmation_url(@resource, :confirmation_token => @resource.confirmation_token)
+p= link_to 'Confirm my account', confirmation_url(@resource, :confirmation_token => @token)

--- a/app/views/devise/mailer/reset_password_instructions.html.slim
+++ b/app/views/devise/mailer/reset_password_instructions.html.slim
@@ -1,6 +1,6 @@
 p
   | Hello #{@resource.email}!
 p Someone has requested a link to change your password, and you can do this through the link below.
-p= link_to 'Change my password', edit_password_url(@resource, :reset_password_token => @resource.reset_password_token)
+p= link_to 'Change my password', edit_password_url(@resource, :reset_password_token => @token)
 p If you didn't request this, please ignore this email.
 p Your password won't change until you access the link above and create a new one.

--- a/app/views/devise/mailer/unlock_instructions.html.slim
+++ b/app/views/devise/mailer/unlock_instructions.html.slim
@@ -2,4 +2,4 @@ p
   | Hello #{@resource.email}!
 p Your account has been locked due to an excessive amount of unsuccessful sign in attempts.
 p Click the link below to unlock your account:
-p= link_to 'Unlock my account', unlock_url(@resource, :unlock_token => @resource.unlock_token)
+p= link_to 'Unlock my account', unlock_url(@resource, :unlock_token => @token)

--- a/app/views/devise/passwords/edit.html.slim
+++ b/app/views/devise/passwords/edit.html.slim
@@ -1,17 +1,19 @@
-h2 Change your password
-= semantic_form_for resource, :as => resource_name, :url => password_path(resource_name), :html => { :method => :put } do |f|
-  = devise_error_messages!
+.row
+  .col-xs-12
+    h2 Change your password
+    = semantic_form_for resource, :as => resource_name, :url => password_path(resource_name), :html => { :method => :put } do |f|
+      = devise_error_messages!
 
-  = f.inputs do
-    = f.input :password
-    = f.input :password_confirmation
-    = f.input :reset_password_token, :as => 'hidden'
+      = f.inputs do
+        = f.input :password
+        = f.input :password_confirmation
+        = f.input :reset_password_token, :as => 'hidden'
 
-    = f.input :name, :as => 'hidden', :input_html => { :value => 'x' }
-    = f.input :phone, :as => 'hidden', :input_html => { :value => 'x' }
-    = f.input :address_1, :as => 'hidden', :input_html => { :value => 'x' }
-    = f.input :city, :as => 'hidden', :input_html => { :value => 'x' }
-    = f.input :country, :as => 'hidden', :input_html => { :value => 'x' }
-  = f.buttons do
-    = f.commit_button :change_my_password
-= render :partial => "devise/shared/links"
+        = f.input :name, :as => 'hidden', :input_html => { :value => 'x' }
+        = f.input :phone, :as => 'hidden', :input_html => { :value => 'x' }
+        = f.input :address_1, :as => 'hidden', :input_html => { :value => 'x' }
+        = f.input :city, :as => 'hidden', :input_html => { :value => 'x' }
+        = f.input :country, :as => 'hidden', :input_html => { :value => 'x' }
+      = f.actions do
+        = f.action :submit, label: :change_my_password
+    = render :partial => "devise/shared/links"

--- a/app/views/devise/passwords/new.html.slim
+++ b/app/views/devise/passwords/new.html.slim
@@ -1,11 +1,13 @@
-h2 Forgot your password?
-= semantic_form_for resource, :as => resource_name, :url => password_path(resource_name), :html => { :method => :post } do |f|
-  - ee=devise_error_messages!
-  - if !ee.empty?
-    .error
-      = t('email_not_found')
-  = f.inputs do
-    = f.input :email
-  = f.buttons do
-    = f.commit_button :send_me_reset_password_instructions
-= render :partial => "devise/shared/links"
+.row.
+  .col-xs-12
+    h2 Forgot your password?
+    = semantic_form_for resource, :as => resource_name, :url => password_path(resource_name), :html => { :method => :post } do |f|
+      - ee=devise_error_messages!
+      - if !ee.empty?
+        .error
+          = t('email_not_found')
+      = f.inputs do
+        = f.input :email
+      = f.actions do
+        = f.action :submit, label: :send_me_reset_password_instructions
+    = render :partial => "devise/shared/links"

--- a/app/views/devise/registrations/edit.html.slim
+++ b/app/views/devise/registrations/edit.html.slim
@@ -1,25 +1,27 @@
-h1 My Account
-= semantic_form_for resource, :as => resource_name, :url => registration_path(resource_name), :html => { :method => :put } do |f|
-  = devise_error_messages!
-  = f.inputs do
-    = f.input :email
-    = f.input :password
-    = f.input :password_confirmation
-    = f.input :current_password, :required => true
-    = f.input :name
-    = f.input :job_title
-    = f.input :department
-    = f.input :organization
-    = f.input :phone
-    = f.input :fax
-    = f.input :address_1
-    = f.input :address_2
-    = f.input :address_3
-    = f.input :city
-    = f.input :country
-  = f.buttons do
-    = f.commit_button :update
+.row
+  .col-xs-12
+    h1 My Account
+    = semantic_form_for resource, :as => resource_name, :url => registration_path(resource_name), :html => { :method => :put } do |f|
+      = devise_error_messages!
+      = f.inputs do
+        = f.input :email
+        = f.input :password
+        = f.input :password_confirmation
+        = f.input :current_password, :required => true
+        = f.input :name
+        = f.input :job_title
+        = f.input :department
+        = f.input :organization
+        = f.input :phone
+        = f.input :fax
+        = f.input :address_1
+        = f.input :address_2
+        = f.input :address_3
+        = f.input :city
+        = f.input :country
+      = f.actions do
+        = f.action :submit
 
-h3 Cancel my account
-p= button_to "Cancel my account", registration_path(resource_name), :confirm => "Are you sure?", :method => :delete
-p= link_to "Back", :back
+    h3 Cancel my account
+    p= button_to "Cancel my account", registration_path(resource_name), :confirm => "Are you sure?", :method => :delete
+    p= link_to "Back", :back

--- a/app/views/devise/registrations/new.html.slim
+++ b/app/views/devise/registrations/new.html.slim
@@ -1,26 +1,28 @@
-h1 Register
-= semantic_form_for resource, :as => resource_name , :url => registration_path(resource_name) do |f|
-  = devise_error_messages!
-  = f.inputs do
-    = f.input :email
-    = f.input :password
-    = f.input :password_confirmation, :required => true
-    = f.input :name
-    = f.input :job_title
-    = f.input :department
-    = f.input :organization
-    = f.input :phone
-    = f.input :fax
-    = f.input :address_1
-    = f.input :address_2
-    = f.input :address_3
-    = f.input :city
-    = f.input :country
-  = f.buttons do
-    = f.commit_button :register
+.row
+  .col-xs-12
+    h1 Register
+    = semantic_form_for resource, :as => resource_name , :url => registration_path(resource_name) do |f|
+      = devise_error_messages!
+      = f.inputs do
+        = f.input :email
+        = f.input :password
+        = f.input :password_confirmation, :required => true
+        = f.input :name
+        = f.input :job_title
+        = f.input :department
+        = f.input :organization
+        = f.input :phone
+        = f.input :fax
+        = f.input :address_1
+        = f.input :address_2
+        = f.input :address_3
+        = f.input :city
+        = f.input :country
+      = f.actions do
+        = f.submit :register
 
-= render :partial => "devise/shared/links"
+    = render :partial => "devise/shared/links"
 
-/!/ resource, :as => resource_name, :url => registration_path(resource_name)
-/!/ %p= f.submit "Register"
-/!/ = f.buttons
+    /!/ resource, :as => resource_name, :url => registration_path(resource_name)
+    /!/ %p= f.submit "Register"
+    /!/ = f.buttons

--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -1,13 +1,12 @@
-.container
-  .row
-    .col-xs-12
-      h1 Log in
-      = semantic_form_for resource, :as => resource_name, :url => session_path(resource_name) do |f|
-        = f.inputs do
-          = f.input :email
-          = f.input :password
-          - if devise_mapping.rememberable?
-            = f.input :remember_me, :as => :boolean
-        = f.actions do
-          = f.action :submit, label: 'Log in'
-      = render :partial => "devise/shared/links"
+.row
+  .col-xs-12
+    h1 Log in
+    = semantic_form_for resource, :as => resource_name, :url => session_path(resource_name) do |f|
+      = f.inputs do
+        = f.input :email
+        = f.input :password
+        - if devise_mapping.rememberable?
+          = f.input :remember_me, :as => :boolean
+      = f.actions do
+        = f.action :submit, label: 'Log in'
+    = render :partial => "devise/shared/links"

--- a/app/views/devise/unlocks/new.html.slim
+++ b/app/views/devise/unlocks/new.html.slim
@@ -1,9 +1,11 @@
-h2 Resend unlock instructions
-= form_for(resource, :as => resource_name, :url => unlock_path(resource_name), :html => { :method => :post }) do |f|
-  = devise_error_messages!
-  p
-    = f.label :email
-    br/
-    = f.text_field :email
-  p= f.submit "Resend unlock instructions"
-= render :partial => "devise/shared/links"
+.row
+  .col-xs-12
+    h2 Resend unlock instructions
+    = form_for(resource, :as => resource_name, :url => unlock_path(resource_name), :html => { :method => :post }) do |f|
+      = devise_error_messages!
+      p
+        = f.label :email
+        br/
+        = f.text_field :email
+      p= f.submit "Resend unlock instructions"
+    = render :partial => "devise/shared/links"

--- a/app/views/find/historical.html.slim
+++ b/app/views/find/historical.html.slim
@@ -1,5 +1,7 @@
-a target='_top' href="/report/#{@species}/#{@year}/#{@continent}/#{@region}/#{@country}/#{@objectid}" 
-  | If you aren't redirected, click here.
+.row
+  .col-xs-12
+    a target='_top' href="/report/#{@species}/#{@year}/#{@continent}/#{@region}/#{@country}/#{@objectid}" 
+      | If you aren't redirected, click here.
 
-javascript:
-  | window.parent.location.href = "/report/#{escape_once @species}/#{escape_once @year}/#{escape_once @continent}/#{escape_once @region}/#{escape_once @country}/#{escape_once @objectid}"
+    javascript:
+      window.parent.location.href = "/report/#{escape_once @species}/#{escape_once @year}/#{escape_once @continent}/#{escape_once @region}/#{escape_once @country}/#{escape_once @objectid}"

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -58,13 +58,16 @@ html
           .error= flash[:error]
         - if(!flash[:success].nil?)
           .success= flash[:success]
-    = yield
     .container
-      span#iucn-logos
-        a#logo-iucn href='http://www.iucn.org/'
-          = image_tag 'iucn_logo.jpg', :alt=>'IUCN'
-        a#logo-ssc href='http://www.iucn.org/about/work/programmes/species/about_ssc/'
-          = image_tag 'ssc2005web_res.gif', :alt=>'Species Survival Commission'
-      span#legal
-        p
-          = t('legal').gsub('$today$',"#{Date.today.year}")
+      = yield
+    .container
+      .row style='margin-top: 10px;'
+        .col-xs-12
+          span#iucn-logos
+            a#logo-iucn href='http://www.iucn.org/'
+              = image_tag 'iucn_logo.jpg', :alt=>'IUCN'
+            a#logo-ssc href='http://www.iucn.org/about/work/programmes/species/about_ssc/'
+              = image_tag 'ssc2005web_res.gif', :alt=>'Species Survival Commission'
+          span#legal
+            p
+              = t('legal').gsub('$today$',"#{Date.today.year}")

--- a/app/views/layouts/count_crud_form.html.slim
+++ b/app/views/layouts/count_crud_form.html.slim
@@ -1,0 +1,12 @@
+.row
+  .col-xs-12
+    h1 = @title
+    .restated_survey_info
+      = render :partial => "submission_info", :locals => { :s => @submission }
+    = semantic_form_for @level do |f|
+      = render "shared/error_messages", :target => @level
+      = f.inputs do
+        = f.input :population_submission_id, :as => :hidden, :value => @population_submission.id
+        = f.input :surveyed_at_stratum_level, :as => :radio
+        = f.input :stratum_level_data_submitted, :as => :radio
+      = f.actions

--- a/app/views/layouts/internal.html.slim
+++ b/app/views/layouts/internal.html.slim
@@ -15,4 +15,5 @@ html
         | padding-right: 5px;
       | }
   body style=("background: #fff; padding: 50px") 
-    = yield
+    .container
+      = yield

--- a/app/views/layouts/survey_crud_form.html.slim
+++ b/app/views/layouts/survey_crud_form.html.slim
@@ -1,0 +1,4 @@
+.row
+  .col-xs-12
+    h1 = @title
+    = render 'form'

--- a/app/views/layouts/survey_display.html.slim
+++ b/app/views/layouts/survey_display.html.slim
@@ -1,0 +1,6 @@
+.row
+  .col-xs-12
+    h1 = @title
+    .restated_survey_info
+      = render :partial => "submission_info", :locals => { :s => @submission }
+    == map_aggregate @level

--- a/app/views/population_submission_attachments/_form.html.slim
+++ b/app/views/population_submission_attachments/_form.html.slim
@@ -25,5 +25,5 @@
         | GIS geometries) will be attributed using the citation you provided here.
       = f.input :restrict
       = f.input :file
-  = f.buttons do
-    = f.commit_button
+  = f.actions do
+    = f.action :submit

--- a/app/views/population_submission_attachments/edit.html.slim
+++ b/app/views/population_submission_attachments/edit.html.slim
@@ -1,2 +1,4 @@
-h1 Edit Attachment
-= render 'form'
+.row
+  .col-xs-12
+    h1 Edit Attachment
+    = render 'form'

--- a/app/views/population_submission_attachments/index.html.slim
+++ b/app/views/population_submission_attachments/index.html.slim
@@ -1,14 +1,15 @@
-h1= t('.title')
-p= link_to t('.new'), new_population_submission_attachment_path
+.row
+  .col-xs-12
+    h1= t('.title')
+    p= link_to t('.new'), new_population_submission_attachment_path
 
-table
-  thead
-    tr
-      th colspan=3 = t 'actions'
-  
-  tbody
-    - for population_submission_attachment in @population_submission_attachments
-      tr  class=cycle(:odd, :even)  
-        td.action= link_to t('show'), population_submission_attachment
-        td.action= link_to t('edit'), edit_population_submission_attachment_path(population_submission_attachment)
-        td.action= link_to t('destroy'), population_submission_attachment, :confirm => t('are_you_sure'), :method => :delete
+    table.table
+      thead
+        tr
+          th colspan=3 = t 'actions'
+      tbody
+        - for population_submission_attachment in @levels
+          tr  class=cycle(:odd, :even)  
+            td.action= link_to t('show'), population_submission_attachment
+            td.action= link_to t('edit'), edit_population_submission_attachment_path(population_submission_attachment)
+            td.action= link_to t('destroy'), population_submission_attachment, :confirm => t('are_you_sure'), :method => :delete

--- a/app/views/population_submission_attachments/new.html.slim
+++ b/app/views/population_submission_attachments/new.html.slim
@@ -1,2 +1,4 @@
-h1 Attach File
-= render 'form'
+.row
+  .col-xs-12
+    h1 Attach File
+    = render 'form'

--- a/app/views/population_submission_attachments/show.html.slim
+++ b/app/views/population_submission_attachments/show.html.slim
@@ -1,28 +1,30 @@
-h1 Attachment
-.restated_survey_info
-  = render :partial => "submission_info", :locals => { :s => @submission }
-h4= @population_submission_attachment.file_file_name
-.attachment_details
-  | Details:
-  = @population_submission_attachment.file_file_size
-  | bytes,
-  = @population_submission_attachment.file_content_type
+.row
+  .col-xs-12
+    h1 Attachment
+    .restated_survey_info
+      = render :partial => "submission_info", :locals => { :s => @submission }
+    h4= @population_submission_attachment.file_file_name
+    .attachment_details
+      | Details:
+      = @population_submission_attachment.file_file_size
+      | bytes,
+      = @population_submission_attachment.file_content_type
 
-div
-  | Uploaded:
-  = time_ago_in_words @population_submission_attachment.created_at
-  | ago
+    div
+      | Uploaded:
+      = time_ago_in_words @population_submission_attachment.created_at
+      | ago
 
-div
-  | Type:
-  = @population_submission_attachment.attachment_type
+    div
+      | Type:
+      = @population_submission_attachment.attachment_type
 
-div
-  | Restricted:
-  = @population_submission_attachment.restrict?
+    div
+      | Restricted:
+      = @population_submission_attachment.restrict?
 
-.download
-  =link_to "Download", "/population_submission_attachments/download/#{@population_submission_attachment.id}"
-  | \
-  =link_to "Remove", @population_submission_attachment, :confirm => "You are about to remove the file \"#{@population_submission_attachment.file_file_name}\". Do you wish to proceed?", :method => :delete
+    .download
+      =link_to "Download", "/population_submission_attachments/download/#{@population_submission_attachment.id}"
+      | \
+      =link_to "Remove", @population_submission_attachment, :confirm => "You are about to remove the file \"#{@population_submission_attachment.file_file_name}\". Do you wish to proceed?", :method => :delete
 

--- a/app/views/population_submissions/_form.html.slim
+++ b/app/views/population_submissions/_form.html.slim
@@ -16,17 +16,17 @@
     = f.input :completion_month, :as => :select, :collection => {"January" => 1, "February" => 2, "March" => 3, "April" => 4, "May" => 5, "June" => 6, "July" => 7, "August" => 8, "September" => 9, "October" => 10, "November" => 11, "December" => 12}
     = f.input :season, :as => :select, :collection => ["Wet", "Dry", "Both", "Unknown"]
     = f.input :survey_type, :as => :select, :collection => {"Aerial total count (AT)" => 'AT', "Aerial sample count (AS)" => 'AS', "Ground total count (GT)" => 'GT', "Ground sample count (GS)" => 'GS', "Dung count (DC)" => 'DC', "Faecal DNA survey (GD)" => 'GD', "Individual registration (IR)" => 'IR', "Other" => 'O'}
-  = f.buttons
+  = f.actions
 
 javascript:
-  | function hide_and_show_things(){
-    | $('#population_submission_data_licensing_ccem').each(function(){
-      | if(this.checked == true){
-        | $('#population_submission_embargo_date_input').show()
-      | } else {
-        | $('#population_submission_embargo_date_input').hide()
-      | }
-    | })
-  | }
-  | $('input[type=radio]').change(hide_and_show_things);
-  | hide_and_show_things();
+  function hide_and_show_things(){
+    $('#population_submission_data_licensing_ccem').each(function(){
+      if(this.checked == true){
+        $('#population_submission_embargo_date_input').show()
+      } else {
+        $('#population_submission_embargo_date_input').hide()
+      }
+    })
+  }
+  $('input[type=radio]').change(hide_and_show_things);
+  hide_and_show_things();

--- a/app/views/population_submissions/analysis_2013.html.slim
+++ b/app/views/population_submissions/analysis_2013.html.slim
@@ -1,31 +1,33 @@
-h1 = t '.title'
+.row
+  .col-xs-12
+    h1 = t '.title'
 
-.info
-  |  These are the data submitted between 2007 and 2014
+    .info
+      |  These are the data submitted between 2007 and 2014
 
-table
-  thead
-    tr
-      th= sortable 'site_name', 'Input Zone'
-      th= sortable 'country', 'Country'
-      th= sortable 'survey_type', 'Type of Survey'
-      th= sortable 'completion_year', 'Year of Survey'
-      th Estimate
-      th= sortable 'citation', 'Source'
-      th= sortable 'data_licensing', 'Data Licensing'
+    table.table
+      thead
+        tr
+          th= sortable 'site_name', 'Input Zone'
+          th= sortable 'country', 'Country'
+          th= sortable 'survey_type', 'Type of Survey'
+          th= sortable 'completion_year', 'Year of Survey'
+          th Estimate
+          th= sortable 'citation', 'Source'
+          th= sortable 'data_licensing', 'Data Licensing'
 
-  tbody
-    - for p in @population_submissions
-      - if p.released? or (!current_user.nil? and current_user.admin?)
-        - if p.submitted?
-          tr class=cycle(:odd, :even)
-            td
-              - unless p.released?
-                = link_to p do
-                  = "#{p.site_name} #{p.designate}"
-            td = (p.submission.nil? or p.submission.country.nil?) ? '???' : p.submission.country.name
-            td = p.survey_type
-            td = p.completion_year
-            td = p.estimate
-            td = p.source
-            td == p.data_licensing_link
+      tbody
+        - for p in @population_submissions
+          - if p.released? or (!current_user.nil? and current_user.admin?)
+            - if p.submitted?
+              tr class=cycle(:odd, :even)
+                td
+                  - unless p.released?
+                    = link_to p do
+                      = "#{p.site_name} #{p.designate}"
+                td = (p.submission.nil? or p.submission.country.nil?) ? '???' : p.submission.country.name
+                td = p.survey_type
+                td = p.completion_year
+                td = p.estimate
+                td = p.source
+                td == p.data_licensing_link

--- a/app/views/population_submissions/edit.html.slim
+++ b/app/views/population_submissions/edit.html.slim
@@ -1,14 +1,16 @@
-h1= t '.title'
-= render 'form'
+.row
+  .col-xs-12
+    h1= t '.title'
+    = render 'form'
 
-- @f_lat = @population_submission.latitude.blank? ? 0 : @population_submission.latitude
-- @f_long = @population_submission.longitude.blank? ? 0 : @population_submission.longitude
+    - @f_lat = @population_submission.latitude.blank? ? 0 : @population_submission.latitude
+    - @f_long = @population_submission.longitude.blank? ? 0 : @population_submission.longitude
 
-javascript:
-  | jQuery(document).ready(function($){
-    | window.load_google_maps(function(){
-      | ft_initialize_below_protareax('map_canvas', 2899026, 'geometry', 'ROWID', '/popup/2007/', 3, new google.maps.LatLng(0,0), function(){
-        | addExistingZone(#{@population_submission.id},#{@f_lat},#{@f_long});
-      | });
-    | });
-  | });
+    javascript:
+      jQuery(document).ready(function($){
+        window.load_google_maps(function(){
+          ft_initialize_below_protareax('map_canvas', 2899026, 'geometry', 'ROWID', '/popup/2007/', 3, new google.maps.LatLng(0,0), function(){
+            addExistingZone(#{@population_submission.id},#{@f_lat},#{@f_long});
+          });
+        });
+      });

--- a/app/views/population_submissions/index.html.slim
+++ b/app/views/population_submissions/index.html.slim
@@ -1,36 +1,38 @@
-h1 = t '.title'
+.row
+  .col-xs-12
+    h1 = t '.title'
 
-.info
-  |  These are the most recent surveys that have been submitted after the 2013 analysis.
-  |  They have not yet been reviewed by the appropriate Data Review
-  |  Working Group.
+    .info
+      |  These are the most recent surveys that have been submitted after the 2013 analysis.
+      |  They have not yet been reviewed by the appropriate Data Review
+      |  Working Group.
 
-table
-  thead
-    tr
-      th= sortable 'site_name', 'Input Zone'
-      th= sortable 'country', 'Country'
-      th= sortable 'survey_type', 'Type of Survey'
-      th= sortable 'completion_year', 'Year of Survey'
-      th Estimate
-      th= sortable 'citation', 'Source'
-      th= sortable 'data_licensing', 'Data Licensing'
-      th= sortable 'created_at', 'Date Created'
+    table.table
+      thead
+        tr
+          th= sortable 'site_name', 'Input Zone'
+          th= sortable 'country', 'Country'
+          th= sortable 'survey_type', 'Type of Survey'
+          th= sortable 'completion_year', 'Year of Survey'
+          th Estimate
+          th= sortable 'citation', 'Source'
+          th= sortable 'data_licensing', 'Data Licensing'
+          th= sortable 'created_at', 'Date Created'
 
-  tbody
-    - for p in @population_submissions
-      - if p.released? or (!current_user.nil? and current_user.admin?)
-        - if p.submitted?
-          tr class=cycle(:odd, :even)
-            td
-              - unless p.released?
-                strong NEW
-              = link_to p do
-                = "#{p.site_name} #{p.designate}"
-            td = (p.submission.nil? or p.submission.country.nil?) ? '???' : p.submission.country.name
-            td = p.survey_type
-            td = p.completion_year
-            td = p.estimate
-            td = p.source
-            td == p.data_licensing_link
-            td = p.created_at
+      tbody
+        - for p in @population_submissions
+          - if p.released? or (!current_user.nil? and current_user.admin?)
+            - if p.submitted?
+              tr class=cycle(:odd, :even)
+                td
+                  - unless p.released?
+                    strong NEW
+                  = link_to p do
+                    = "#{p.site_name} #{p.designate}"
+                td = (p.submission.nil? or p.submission.country.nil?) ? '???' : p.submission.country.name
+                td = p.survey_type
+                td = p.completion_year
+                td = p.estimate
+                td = p.source
+                td == p.data_licensing_link
+                td = p.created_at

--- a/app/views/population_submissions/my.html.slim
+++ b/app/views/population_submissions/my.html.slim
@@ -1,34 +1,36 @@
-h1 = t '.title'
+.row
+  .col-xs-12
+    h1 = t '.title'
 
-table
-  thead
-    tr
-      th Input Zone
-      th Country
-      th Type of Survey
-      th Year of Survey
-      th Estimate
-      th Source
-      th Data Licensing
-      th Created
-      th Submitted
-      th Released
+    table.table
+      thead
+        tr
+          th Input Zone
+          th Country
+          th Type of Survey
+          th Year of Survey
+          th Estimate
+          th Source
+          th Data Licensing
+          th Created
+          th Submitted
+          th Released
 
-  tbody
-    - for p in @population_submissions
-      tr class=cycle(:odd, :even)
-        td
-          - unless p.released?
-            strong NEW 
-          = link_to p do
-            = "#{p.site_name} #{p.designate}"
-        td = (p.submission.nil? or p.submission.country.nil?) ? '???' : p.submission.country.name
-        td = p.survey_type
-        td = p.completion_year
-        td = p.estimate
-        td = p.source
-        td == p.data_licensing_link
-        td = p.created_at
-        td = p.submitted?? 'Y' : 'N'
-        td = p.released?? 'Y' : 'N'
+      tbody
+        - for p in @population_submissions
+          tr class=cycle(:odd, :even)
+            td
+              - unless p.released?
+                strong NEW 
+              = link_to p do
+                = "#{p.site_name} #{p.designate}"
+            td = (p.submission.nil? or p.submission.country.nil?) ? '???' : p.submission.country.name
+            td = p.survey_type
+            td = p.completion_year
+            td = p.estimate
+            td = p.source
+            td == p.data_licensing_link
+            td = p.created_at
+            td = p.submitted?? 'Y' : 'N'
+            td = p.released?? 'Y' : 'N'
 

--- a/app/views/population_submissions/new.html.slim
+++ b/app/views/population_submissions/new.html.slim
@@ -1,14 +1,16 @@
-h1= t '.title'
-= render 'form'
+.row
+  .col-xs-12
+    h1= t '.title'
+    = render 'form'
 
-- @f_lat = @population_submission.latitude.blank? ? 0 : @population_submission.latitude
-- @f_long = @population_submission.longitude.blank? ? 0 : @population_submission.longitude
+    - @f_lat = @population_submission.latitude.blank? ? 0 : @population_submission.latitude
+    - @f_long = @population_submission.longitude.blank? ? 0 : @population_submission.longitude
 
-javascript:
-  | jQuery(document).ready(function($){
-    | window.load_google_maps(function(){
-      | ft_initialize_below_protareax('map_canvas', 2899026, 'geometry', 'ROWID', '/popup/2007/', 3, new google.maps.LatLng(0,0), function(){
-        | addExistingZone(0,#{@f_lat},#{@f_long});
-      | });
-    | });
-  | });
+    javascript:
+      jQuery(document).ready(function($){
+        window.load_google_maps(function(){
+          ft_initialize_below_protareax('map_canvas', 2899026, 'geometry', 'ROWID', '/popup/2007/', 3, new google.maps.LatLng(0,0), function(){
+            addExistingZone(0,#{@f_lat},#{@f_long});
+          });
+        });
+      });

--- a/app/views/population_submissions/show.html.slim
+++ b/app/views/population_submissions/show.html.slim
@@ -1,10 +1,12 @@
-h1 Population Survey
-.restated_survey_info
-  =render :partial => 'submission_info', :locals => { :s => @submission }
+.row
+  .col-xs-12
+    h1 Population Survey
+    .restated_survey_info
+      =render :partial => 'submission_info', :locals => { :s => @submission }
 
-.public_abstract= @population_submission.abstract
-.public_citation
-  | Source:
-  = @population_submission.citation
-- unless @population_submission.link.blank?
-  .public_link= link_to @population_submission.link
+    .public_abstract= @population_submission.abstract
+    .public_citation
+      | Source:
+      = @population_submission.citation
+    - unless @population_submission.link.blank?
+      .public_link= link_to @population_submission.link

--- a/app/views/population_submissions/submit.html.slim
+++ b/app/views/population_submissions/submit.html.slim
@@ -1,37 +1,39 @@
-h1 Submit Population Data to AfESG
+.row
+  .col-xs-12
+    h1 Submit Population Data to AfESG
 
-.restated_survey_info
-  = render :partial => "submission_info", :locals => { :s => @submission }
-.submit_instructions
-  | When you are done with your submission, complete the fields here to begin
-  | the data review process. If you are publishing this data under a Creative
-  | Commons license, the information you have entered will be released to the
-  | public as soon as an administrator initially reviews the submission -
-  | usually 1-2 business days.
-  p
-  | REMINDER: Have you attached your survey report and relevant geometries? If not,
-  | please add them via the "Attach a file" link, located at the bottom of the summary
-  | on the left, prior to completing this submission.
+    .restated_survey_info
+      = render :partial => "submission_info", :locals => { :s => @submission }
+    .submit_instructions
+      | When you are done with your submission, complete the fields here to begin
+      | the data review process. If you are publishing this data under a Creative
+      | Commons license, the information you have entered will be released to the
+      | public as soon as an administrator initially reviews the submission -
+      | usually 1-2 business days.
+      p
+      | REMINDER: Have you attached your survey report and relevant geometries? If not,
+      | please add them via the "Attach a file" link, located at the bottom of the summary
+      | on the left, prior to completing this submission.
 
-= semantic_form_for @population_submission do |f|
-  = render "shared/error_messages", :target => @population_submission
-  = f.inputs do
-    = f.input :abstract
-    = f.input :link, :as => :string
-    = f.input :citation
-    - if @population_submission.submitted?
-      div
-        | This population survey is already submitted.
-    - else
-      .submit_confirmation
-        | By ticking this box, I acknowledge that I have the rights to submit
-        | this information to the African Elephant Specialist Group and request
-        | review of this submission.
-      = f.input :submitted
-    - if current_user.admin?
-      = f.input :short_citation
-      .submit_confirmation
-        | Admin Use Only: ticking this box will make this submission visible
-        | on the site, pursuant to its data use restrictions.
-      =f.input :released
-  = f.buttons
+    = semantic_form_for @population_submission do |f|
+      = render "shared/error_messages", :target => @population_submission
+      = f.inputs do
+        = f.input :abstract
+        = f.input :link, :as => :string
+        = f.input :citation
+        - if @population_submission.submitted?
+          div
+            | This population survey is already submitted.
+        - else
+          .submit_confirmation
+            | By ticking this box, I acknowledge that I have the rights to submit
+            | this information to the African Elephant Specialist Group and request
+            | review of this submission.
+          = f.input :submitted
+        - if current_user.admin?
+          = f.input :short_citation
+          .submit_confirmation
+            | Admin Use Only: ticking this box will make this submission visible
+            | on the site, pursuant to its data use restrictions.
+          =f.input :released
+      = f.actions

--- a/app/views/report/_breadcrumbs.html.slim
+++ b/app/views/report/_breadcrumbs.html.slim
@@ -1,0 +1,21 @@
+- species   = local_assigns[:species] || @species
+- year      = local_assigns[:year] || @year
+- continent = local_assigns[:continent] || @continent
+- region    = local_assigns[:region] || @region
+- country   = local_assigns[:country] || @country
+- survey    = local_assigns[:survey] || @survey_zone
+
+ol.breadcrumb
+  li Reports
+  - if species
+    li = link_to_if year, species, "/report/#{species.gsub(' ','_')}"
+  - if year
+    li = link_to_if continent, year, "/report/#{species.gsub(' ','_')}/#{year}"
+  - if continent
+    li = link_to_if region, continent, "/report/#{species.gsub(' ','_')}/#{year}/#{continent}"
+  - if region
+    li = link_to_if country, region, "/report/#{species.gsub(' ','_')}/#{year}/#{continent}/#{region.gsub(' ','_')}"
+  - if country
+    li = link_to_if survey, country, "/report/#{species.gsub(' ','_')}/#{year}/#{continent}/#{region.gsub(' ','_')}/#{country.gsub(' ','_')}"
+  - if survey
+    li = "#{survey['survey_zone']} #{survey['designate']}"

--- a/app/views/report/_preview_breadcrumbs.html.slim
+++ b/app/views/report/_preview_breadcrumbs.html.slim
@@ -1,0 +1,19 @@
+- species   = local_assigns[:species] || @species
+- year      = local_assigns[:year] || @year
+- continent = local_assigns[:continent] || @continent
+- site      = local_assigns[:site] || @site
+- region    = local_assigns[:region] || @region
+- country   = local_assigns[:country] || @country
+
+
+ol.breadcrumb
+  li = link_to 'Reports', report_path
+  li = link_to species, "/report/#{@species.gsub(' ','_')}"
+  li = year
+  li = link_to_unless region.nil? && site.nil?, continent, "/preview_report/#{@filter}/#{species.gsub(' ','_')}/#{year}/#{continent}"
+  - if region
+    li = link_to_if country, region, "/preview_report/#{@filter}/#{species.gsub(' ','_')}/#{year}/#{continent}/#{region.gsub(' ','_')}"
+    - if country
+      li = country
+  - elsif site
+    li = site

--- a/app/views/report/_table_area_of_range_covered.html.slim
+++ b/app/views/report/_table_area_of_range_covered.html.slim
@@ -1,0 +1,22 @@
+- totals = local_assigns[:totals]
+- sum    = local_assigns[:sums]
+
+- if !totals.nil? && totals.num_tuples > 0
+  h2 Area of Range Covered by Each Data Category (km²)
+  table.table style='font-size:16px' 
+    tr
+      th Data Category
+      th.numeric Known Range
+      th.numeric Possible Range
+      th.numeric Total Range
+    - totals.each do |row|
+      tr style=('height: 24px;') 
+        td= number_with_delimiter row['surveytype']
+        - ['known','possible','total'].each do |key|
+          td.numeric= number_or_zero row[key]
+    - sums.each do |row|
+      tr.totals style=('height: 24px; font-weight: bold') 
+        td Totals
+        - ['known','possible','total'].each do |key|
+          td.numeric= number_or_zero row[key]
+

--- a/app/views/report/_table_causes_of_change.html.slim
+++ b/app/views/report/_table_causes_of_change.html.slim
@@ -1,0 +1,27 @@
+- totals   = local_assigns[:totals]
+- sums     = local_assigns[:sums]
+- hideable = local_assigns[:hideable] || false
+- title    = local_assigns[:title] || 'Interpretation of Changes in Estimates from Previous Report'
+
+- if !totals.nil? && totals.num_tuples > 0
+  h2 class=(hideable ? 'hideable' : nil) = title
+
+  table class=(hideable ? 'table hideable' : 'table') style='font-size:16px' 
+    tr
+      th width='40%'  Cause of Change
+      th.numeric width='15%'  Definite
+      th.numeric width='15%'  Probable
+      th.numeric width='15%'  Possible
+      th.numeric width='15%'  Speculative
+    - totals.each do |row|
+      tr style=('height: 24px;') 
+        td= row['CauseofChange']
+        - ['definite','probable','possible','specul'].each do |key|
+          td.numeric= signed_number row[key]
+    - unless sums.nil?
+      - sums.each do |row|
+        tr.totals style=('height: 24px; font-weight: bold') 
+          td Totals
+          - ['definite','probable','possible','specul'].each do |key|
+            td.numeric= signed_number row[key]
+

--- a/app/views/report/_table_continental_regional_data_quality.html.slim
+++ b/app/views/report/_table_continental_regional_data_quality.html.slim
@@ -1,0 +1,34 @@
+- preview = local_assigns[:preview] || false
+
+- if !@regions.nil? && @regions.num_tuples > 0
+  h2 Continental and Regional Totals and Data Quality
+  table.table style='font-size:16px' 
+    tr
+      th Region
+      th.numeric Definite
+      th.numeric Probable
+      th.numeric Possible
+      th.numeric Speculative
+      th.numeric Range Area (km²)
+      th.numeric % of Continental Range
+      th.numeric % of Range Assessed
+      th.numeric
+        | IQI<sup>1</sup>
+      th.numeric
+        | PFS<sup>2</sup>
+    - @regions.each do |row|
+      - unless row['RANGEAREA'].nil?
+        tr style=('height: 24px;') 
+          td
+            - if preview
+              a href=("/preview_report/#{@filter}/#{@species.gsub(' ','_')}/#{@year}/#{@continent}/#{row['REGION'].gsub(' ','_')}") = row['REGION']
+            - else
+              a href=("/report/#{@species.gsub(' ','_')}/#{@year}/#{@continent}/#{row['REGION'].gsub(' ','_')}") = row['REGION'] 
+          - ['DEFINITE','PROBABLE','POSSIBLE','SPECUL','RANGEAREA','RANGEPERC','SURVRANGPERC','INFQLTYIDX','PFS'].each do |key|
+            td.numeric= number_with_delimiter row[key]
+    - @regions_sum.each do |row|
+      tr.totals style=('height: 24px; font-weight: bold') 
+        td Totals
+        - ['DEFINITE','PROBABLE','POSSIBLE','SPECUL','RANGEAREA','RANGEPERC','SURVRANGPERC','INFQLTYIDX'].each do |key|
+          td.numeric= number_with_delimiter row[key]
+        td

--- a/app/views/report/_table_country_regional_data_quality.html.slim
+++ b/app/views/report/_table_country_regional_data_quality.html.slim
@@ -1,0 +1,31 @@
+- preview = local_assigns[:preview] || false
+
+- if !@countries.nil? && @countries.num_tuples > 0
+  h2 Country and Regional Totals and Data Quality
+  table.table style='font-size:16px' 
+    tr
+      th Country
+      th.numeric Definite
+      th.numeric Probable
+      th.numeric Possible
+      th.numeric Speculative
+      th.numeric Range Area (km²)
+      th.numeric % of Regional Range
+      th.numeric % of Range Assessed
+      th.numeric IQI<sup>1</sup>
+      th.numeric PFS<sup>2</sup>
+    - @countries.each do |row|
+      - unless row['RANGEAREA'].nil?
+        tr style=('height: 24px;') 
+          td
+            - if preview
+              a href=("#{@region.gsub(' ','_')}/#{u row['CNTRYNAME'].gsub(' ','_')}") = row['CNTRYNAME']
+            - else
+              a href=("#{@region.gsub(' ','_')}/#{u row['CNTRYNAME'].gsub(' ','_')}") = row['CNTRYNAME'] 
+          - ['DEFINITE','PROBABLE','POSSIBLE','SPECUL','RANGEAREA','RANGEPERC','SURVRANGPERC','INFQLTYIDX','PFS'].each do |key|
+            td.numeric= number_with_delimiter row[key]
+    - @countries_sum.each do |row|
+      tr.totals style=('height: 24px; font-weight: bold') 
+        td Totals
+        - ['DEFINITE','PROBABLE','POSSIBLE','SPECUL','RANGEAREA','RANGEPERC','SURVRANGPERC','INFQLTYIDX','PFS'].each do |key|
+          td.numeric= number_with_delimiter row[key]

--- a/app/views/report/_table_preview_summary_totals.html.slim
+++ b/app/views/report/_table_preview_summary_totals.html.slim
@@ -1,0 +1,49 @@
+- year           = local_assigns[:year] || @year
+- level          = local_assigns[:level]
+- summary_totals = local_assigns[:totals]
+- baselines   = local_assigns[:baselines]
+
+- if summary_totals.num_tuples > 0
+  h2 style=('margin-top:20px')
+    ' Summary Totals for
+    = level
+
+  table.table style='font-size:16px'
+    tr
+      th width='40%'  Data Category
+      th.numeric width='15%'  Definite
+      th.numeric width='15%'  Probable
+      th.numeric width='15%'  Possible
+      th.numeric width='15%'  Speculative
+    -@sdef = @sprob = @sposs = @sspec = 0
+    -summary_totals.each do |row|
+      tr style=('height: 24px')
+        td= row['SURVEYTYPE']
+        td.numeric= number_with_delimiter row['DEFINITE']
+        - @sdef = @sdef + row['DEFINITE'].to_i
+        td.numeric= number_with_delimiter row['PROBABLE']
+        - @sprob = @sprob + row['PROBABLE'].to_i
+        td.numeric= number_with_delimiter row['POSSIBLE']
+        - @sposs = @sposs + row['POSSIBLE'].to_i
+        td.numeric= number_with_delimiter row['SPECUL']
+        - @sspec = @sspec + row['SPECUL'].to_i
+    tr.totals style=('height: 24px; font-weight: bold')
+      td
+        ' Totals
+        = year
+      td.numeric= number_with_delimiter @sdef
+      td.numeric= number_with_delimiter @sprob
+      td.numeric= number_with_delimiter @sposs
+      td.numeric= number_with_delimiter @sspec
+    - if year==2013
+      - baselines.each do |base|
+        tr.totals style=('height: 24px; font-style: italic;')
+          td Totals 2006
+          td.numeric= number_with_delimiter base['definite']
+          td.numeric= number_with_delimiter base['probable']
+          td.numeric= number_with_delimiter base['possible']
+          td.numeric= number_with_delimiter base['speculative']
+
+- else
+  h2 No estimates were available for #{level} in #{year}
+

--- a/app/views/report/_table_summary_totals.html.slim
+++ b/app/views/report/_table_summary_totals.html.slim
@@ -1,0 +1,33 @@
+- year           = local_assigns[:year] || @year
+- level          = local_assigns[:level]
+- summary_totals = local_assigns[:totals]
+- summary_sums   = local_assigns[:sums]
+
+
+- if summary_totals.num_tuples > 0
+  h2 style=('margin-top:20px') = "#{year} Summary Totals for #{level}"
+
+  table.table style='font-size:16px' 
+    tr
+      th width='40%'  Data Category
+      th.numeric width='15%'  Definite
+      th.numeric width='15%'  Probable
+      th.numeric width='15%'  Possible
+      th.numeric width='15%'  Speculative
+    - summary_totals.each do |row|
+      tr style=('height: 24px') 
+        td= row['SURVEYTYPE']
+        td.numeric= number_with_delimiter row['DEFINITE']
+        td.numeric= number_with_delimiter row['PROBABLE']
+        td.numeric= number_with_delimiter row['POSSIBLE']
+        td.numeric= number_with_delimiter row['SPECUL']
+    - summary_sums.each do |row|
+      tr.totals style=('height: 24px; font-weight: bold') 
+        td Totals #{year}
+        td.numeric= number_with_delimiter row['DEFINITE']
+        td.numeric= number_with_delimiter row['PROBABLE']
+        td.numeric= number_with_delimiter row['POSSIBLE']
+        td.numeric= number_with_delimiter row['SPECUL']
+- else
+  h2 No estimates were available for #{level} in #{year}
+

--- a/app/views/report/_yearly_status.html.slim
+++ b/app/views/report/_yearly_status.html.slim
@@ -1,0 +1,18 @@
+- authors = local_assigns[:authors]
+- year    = local_assigns[:year]
+- r       = year
+
+.report_cover
+  = link_to "/report/#{@species.gsub(' ','_')}/#{r}" do
+    = image_tag "aesr#{r}_cover_150w.png"
+  .more
+    = link_to "/report/#{@species.gsub(' ','_')}/#{r}" do
+      h5 #{r} African Elephant Status Report
+    .authors = authors
+    .links
+      ' Explore the <a href="http://african-elephant.org/aed/aesr2007.html" target="_blank">full text of the #{year} report</a> (PDF) and its
+      = link_to "/report/#{@species.gsub(' ','_')}/#{r}" do
+        ' errata
+      ' or
+      = link_to 'bibliography', '/report/references'
+      | .

--- a/app/views/report/continent.html.slim
+++ b/app/views/report/continent.html.slim
@@ -1,141 +1,33 @@
-h1 # @year} Continental Totals for #{@continent 
-a href='/report' Reports
+.row
+  .col-xs-12
+    h1 #{@year} Continental Totals for #{@continent}
 
-| &gt;
+    = render 'breadcrumbs'
 
-a href=("/report/#{@species.gsub(' '),'_')}"} #{@species 
+    p
+    | All Years for #{@continent}:
 
-| &gt;
+    a href=("/preview_report/2013_africa_final/#{@species.gsub(' ','_')}/2013/#{@continent}")  2013
 
-a href=("/report/#{@species.gsub(' '),'_')}/#{@year}"} #{@year 
+    - @past_years.each do |year|
+      '
+      ' &mdash;
+      = link_to year, "/report/#{@species.gsub(' ','_')}/#{year}/#{@continent}"
 
-| &gt;
+    == narrative
 
-#{@continent}
+    = render 'table_summary_totals', level: @country, totals: @summary_totals_by_continent, sums: @summary_sums_by_continent
 
-p
-| All Years for #{@continent}:
+    = render 'table_causes_of_change', totals: @causes_of_change_by_continent, sums: @causes_of_change_sums_by_continent
 
-a href=("/preview_report/2013_africa_final/#{@species.gsub(' '),'_')}/2013/#{@continent}"  2013
+    = render 'table_area_of_range_covered', totals: @area_of_range_covered_by_continent, sums: @area_of_range_covered_sum_by_continent
 
-| &mdash;
+    = render 'table_continental_regional_data_quality'
 
-a href=("/report/#{@species.gsub(' '),'_')}/2007/#{@continent}"  2007
-
-| &mdash;
-
-a href=("/report/#{@species.gsub(' '),'_')}/2002/#{@continent}"  2002
-
-| &mdash;
-
-a href=("/report/#{@species.gsub(' '),'_')}/1998/#{@continent}"  1998
-
-| &mdash;
-
-a href=("/report/#{@species.gsub(' '),'_')}/1995/#{@continent}"  1995
-
-== narrative
-
-- if @summary_totals_by_continent.num_tuples > 0
-  h2 style=('margin-top:20px'} #{@year} Summary Totals for #{@continent) 
-
-  table style='font-size:16px' 
-    tr
-      th width='40%'  Data Category
-      th.numeric width='15%'  Definite
-      th.numeric width='15%'  Probable
-      th.numeric width='15%'  Possible
-      th.numeric width='15%'  Speculative
-    -@summary_totals_by_continent.each do |row|
-      tr style=('height: 24px') 
-        td= row['SURVEYTYPE']
-        td.numeric= number_with_delimiter row['DEFINITE']
-        td.numeric= number_with_delimiter row['PROBABLE']
-        td.numeric= number_with_delimiter row['POSSIBLE']
-        td.numeric= number_with_delimiter row['SPECUL']
-    -@summary_sums_by_continent.each do |row|
-      tr.totals style=('height: 24px; font-weight: bold') 
-        td Totals # @year 
-        td.numeric= number_with_delimiter row['DEFINITE']
-        td.numeric= number_with_delimiter row['PROBABLE']
-        td.numeric= number_with_delimiter row['POSSIBLE']
-        td.numeric= number_with_delimiter row['SPECUL']
-
-- if !@causes_of_change_by_continent.nil? && @causes_of_change_by_continent.num_tuples > 0
-  h2 Interpretation of Changes in Estimates from Previous Report
-
-  table style='font-size:16px' 
-    tr
-      th width='40%'  Cause of Change
-      th.numeric width='15%'  Definite
-      th.numeric width='15%'  Probable
-      th.numeric width='15%'  Possible
-      th.numeric width='15%'  Speculative
-    - @causes_of_change_by_continent.each do |row|
-      tr style=('height: 24px;') 
-        td= row['CauseofChange']
-        - ['definite','probable','possible','specul'].each do |key|
-          td.numeric= signed_number row[key]
-    - unless @causes_of_change_sums_by_continent.nil?
-      - @causes_of_change_sums_by_continent.each do |row|
-        tr.totals style=('height: 24px; font-weight: bold') 
-          td Totals
-          - ['definite','probable','possible','specul'].each do |key|
-            td.numeric= signed_number row[key]
-
-- if !@area_of_range_covered_by_continent.nil? && @area_of_range_covered_by_continent.num_tuples > 0
-  h2 Area of Range Covered by Each Data Category (km²)
-  table style='font-size:16px' 
-    tr
-      th Data Category
-      th.numeric Known Range
-      th.numeric Possible Range
-      th.numeric Total Range
-    - @area_of_range_covered_by_continent.each do |row|
-      tr style=('height: 24px;') 
-        td= number_with_delimiter row['surveytype']
-        - ['known','possible','total'].each do |key|
-          td.numeric= number_or_zero row[key]
-    - @area_of_range_covered_sum_by_continent.each do |row|
-      tr.totals style=('height: 24px; font-weight: bold') 
-        td Totals
-        - ['known','possible','total'].each do |key|
-          td.numeric= number_or_zero row[key]
-
-- if !@regions.nil? && @regions.num_tuples > 0
-  h2 Continental and Regional Totals and Data Quality
-  table style='font-size:16px' 
-    tr
-      th Region
-      th.numeric Definite
-      th.numeric Probable
-      th.numeric Possible
-      th.numeric Speculative
-      th.numeric Range Area (km²)
-      th.numeric % of Continental Range
-      th.numeric % of Range Assessed
-      th.numeric
-        | IQI<sup>1</sup
-      th.numeric
-        | PFS<sup>2</sup
-    - @regions.each do |row|
-      - unless row['RANGEAREA'].nil?
-        tr style=('height: 24px;') 
-          td
-            a href=("/report/#{@species.gsub(' '),'_')}/#{@year}/#{@continent}/#{row['REGION'].gsub(' ','_')}"} #{row['REGION'] 
-          - ['DEFINITE','PROBABLE','POSSIBLE','SPECUL','RANGEAREA','RANGEPERC','SURVRANGPERC','INFQLTYIDX','PFS'].each do |key|
-            td.numeric= number_with_delimiter row[key]
-    - @regions_sum.each do |row|
-      tr.totals style=('height: 24px; font-weight: bold') 
-        td Totals
-        - ['DEFINITE','PROBABLE','POSSIBLE','SPECUL','RANGEAREA','RANGEPERC','SURVRANGPERC','INFQLTYIDX'].each do |key|
-          td.numeric= number_with_delimiter row[key]
-        td
-
-p
-  sup 1
-  | IQI: Information Quality Index: This index quantifies overall data quality at the regional level based on the precision of estimates and the proportion of assessed elephant range (i.e. range for which estimates are available). The IQI ranges from zero (no reliable information) to one (perfect information).
-p
-  sup 2
-  | PFS: Priority for Future Surveys, ranked from 1 to 5 (highest to lowest). Based on the precision of estimates and the proportion of national range accounted for by the site in question, PFS is a measure of the importance and urgency for future population surveys. All areas of unassessed range have a priority of 1. See Introduction for details on how the PFS is derived.
-== footnote
+    p
+      sup 1
+      == t 'footnotes.iqi'
+    p
+      sup 2
+      == t 'footnotes.pfs'
+    == footnote

--- a/app/views/report/country.html.slim
+++ b/app/views/report/country.html.slim
@@ -1,175 +1,87 @@
-h1 # @country}, #{@year 
+.row
+  .col-xs-12
+    h1 = "#{@country}, #{@year}"
 
-| Reports
+    = render 'breadcrumbs'
 
-| &gt;
+    p
 
-a href=("/report/#{@species.gsub(' '),'_')}"} #{@species 
+    ' All Years for #{@country}:
 
-| &gt;
+    a href=("/preview_report/2013_africa_final/#{@species.gsub(' ','_')}/2013/#{@continent}/#{@region.gsub(' ','_')}/#{@country.gsub(' ','_')}") = 2013
 
-a href=("/report/#{@species.gsub(' '),'_')}/#{@year}"} #{@year 
+    - @past_years.each do |year|
+      '
+      ' &mdash;
+      = link_to year, "/report/#{@species.gsub(' ','_')}/#{year}/#{@continent}/#{@region.gsub(' ','_')}/#{@country.gsub(' ','_')}"
 
-| &gt;
+    == narrative
 
-a href=("/report/#{@species.gsub(' '),'_')}/#{@year}/#{@continent}"} #{@continent 
+    = render 'table_summary_totals', level: @country, totals: @summary_totals_by_country, sums: @summary_sums_by_country
 
-| &gt;
+    = render 'table_causes_of_change', totals: @causes_of_change_by_country, sums: @causes_of_change_sums_by_country
 
-a href=("/report/#{@species.gsub(' '),'_')}/#{@year}/#{@continent}/#{@region.gsub(' ','_')}"} #{@region 
+    = render 'table_area_of_range_covered', totals: @area_of_range_covered_by_country, sums: @area_of_range_covered_sum_by_country
 
-| &gt; #{@country}
+    - if @elephant_estimates_by_country.num_tuples > 0
+      h2 #{@country} : Elephant Estimates
+      table.table
+        tr
+          th style="border:none" 
+            - if @year.to_i==2007
+              th style="border:none"  Cause of
+          th colspan=3 style="text-align:center" 
+            | Survey Details
+            sup 2
+          th colspan=2 style="text-align:center"  Number of Elephants
+          th style="border:none" 
+          th style="border:none" 
+          th.numeric style=("border:none; padding-right:10px")  Area
+          th colspan=2 style="text-align:center"  Map Location
+        tr
+          th Input Zone
+          - if @year.to_i==2007
+            th
+              | Change
+              sup 1
+          th Type
+          th Reliab.
+          th Year
+          th.numeric Estimate
+          th.numeric 95% C.L.
+          th style="padding-left:10px"  Source
+          th
+            | PFS
+            sup 3
+          th.numeric style="padding-right:10px"  (km²)
+          th style='text-align:center'  Lon.
+          th style='text-align:center'  Lat.
+        - @elephant_estimates_by_country.each do |row|
+          tr style='height:18px' 
+            td
+              a href=("#{@country.gsub(' ','_')}/#{row['OBJECTID']}") = row['survey_zone']
+            - if @year.to_i==2007
+              td= row['ReasonForChange']
+            td= row['method_and_quality']
+            td style="text-align:center" = row['CATEGORY']
+            td= row['CYEAR']
+            td.numeric= number_with_delimiter row['ESTIMATE']
+            td.numeric= number_with_delimiter row['CL95']
+            td style="padding-left:10px" = row['REFERENCE']
+            td style='text-align:center' = row['PFS']
+            td.numeric style="padding-right:10px" = number_with_delimiter row['AREA_SQKM']
+            td style='text-align:center' = row['LON']
+            td style='text-align:center' = row['LAT']
 
-p
-| All Years for #{@country}:
-
-a href=("/preview_report/2013_africa_final/#{@species.gsub(' '),'_')}/2013/#{@continent}/#{@region.gsub(' ','_')}/#{@country.gsub(' ','_')}"  2013
-
-| &mdash;
-
-a href=("/report/#{@species.gsub(' '),'_')}/2007/#{@continent}/#{@region.gsub(' ','_')}/#{@country.gsub(' ','_')}"  2007
-
-| &mdash;
-
-a href=("/report/#{@species.gsub(' '),'_')}/2002/#{@continent}/#{@region.gsub(' ','_')}/#{@country.gsub(' ','_')}"  2002
-
-| &mdash;
-
-a href=("/report/#{@species.gsub(' '),'_')}/1998/#{@continent}/#{@region.gsub(' ','_')}/#{@country.gsub(' ','_')}"  1998
-
-| &mdash;
-
-a href=("/report/#{@species.gsub(' '),'_')}/1995/#{@continent}/#{@region.gsub(' ','_')}/#{@country.gsub(' ','_')}"  1995
-
-
-== narrative
-
-- if @summary_totals_by_country.num_tuples > 0
-  h2 style=('margin-top:20px'} #{@year} Summary Totals for #{@country) 
-
-  table style='font-size:16px' 
-    tr
-      th width='40%'  Data Category
-      th.numeric width='15%'  Definite
-      th.numeric width='15%'  Probable
-      th.numeric width='15%'  Possible
-      th.numeric width='15%'  Speculative
-    -@summary_totals_by_country.each do |row|
-      tr style=('height: 24px') 
-        td= row['SURVEYTYPE']
-        td.numeric= number_with_delimiter row['DEFINITE']
-        td.numeric= number_with_delimiter row['PROBABLE']
-        td.numeric= number_with_delimiter row['POSSIBLE']
-        td.numeric= number_with_delimiter row['SPECUL']
-    -@summary_sums_by_country.each do |row|
-      tr.totals style=('height: 24px; font-weight: bold') 
-        td Totals # @year 
-        td.numeric= number_with_delimiter row['DEFINITE']
-        td.numeric= number_with_delimiter row['PROBABLE']
-        td.numeric= number_with_delimiter row['POSSIBLE']
-        td.numeric= number_with_delimiter row['SPECUL']
-- else
-  h2 No estimates were available for # @country} in #{@year 
-- if !@causes_of_change_by_country.nil? && @causes_of_change_by_country.num_tuples > 0
-  h2 Interpretation of Changes in Estimates from Previous Report
-
-  table style='font-size:16px' 
-    tr
-      th width='40%'  Cause of Change
-      th.numeric width='15%'  Definite
-      th.numeric width='15%'  Probable
-      th.numeric width='15%'  Possible
-      th.numeric width='15%'  Speculative
-    - @causes_of_change_by_country.each do |row|
-      tr style=('height: 24px;') 
-        td= row['CauseofChange']
-        - ['definite','probable','possible','specul'].each do |key|
-          td.numeric= signed_number row[key]
-    - unless @causes_of_change_sums_by_country.nil?
-      - @causes_of_change_sums_by_country.each do |row|
-        tr.totals style=('height: 24px; font-weight: bold') 
-          td Totals
-          - ['definite','probable','possible','specul'].each do |key|
-            td.numeric= signed_number row[key]
-
-- if !@area_of_range_covered_by_country.nil? && @area_of_range_covered_by_country.num_tuples > 0
-  h2 Area of Range Covered by Each Data Category (km²)
-  table style='font-size:16px' 
-    tr
-      th Data Category
-      th.numeric Known Range
-      th.numeric Possible Range
-      th.numeric Total Range
-    - @area_of_range_covered_by_country.each do |row|
-      tr style=('height: 24px;') 
-        td= number_with_delimiter row['surveytype']
-        - ['known','possible','total'].each do |key|
-          td.numeric= number_or_zero row[key]
-    - @area_of_range_covered_sum_by_country.each do |row|
-      tr.totals style=('height: 24px; font-weight: bold') 
-        td Totals
-        - ['known','possible','total'].each do |key|
-          td.numeric= number_or_zero row[key]
-
-- if @elephant_estimates_by_country.num_tuples > 0
-  h2 # @country : Elephant Estimates
-  table
-    tr
-      th style="border:none" 
-        - if @year.to_i==2007
-          th style="border:none"  Cause of
-      th colspan=3 style="text-align:center" 
-        | Survey Details
-        sup 2
-      th colspan=2 style="text-align:center"  Number of Elephants
-      th style="border:none" 
-      th style="border:none" 
-      th.numeric style=("border:none; padding-right:10px")  Area
-      th colspan=2 style="text-align:center"  Map Location
-    tr
-      th Input Zone
-      - if @year.to_i==2007
-        th
-          | Change
-          sup 1
-      th Type
-      th Reliab.
-      th Year
-      th.numeric Estimate
-      th.numeric 95% C.L.
-      th style="padding-left:10px"  Source
-      th
-        | PFS
-        sup 3
-      th.numeric style="padding-right:10px"  (km²)
-      th style='text-align:center'  Lon.
-      th style='text-align:center'  Lat.
-    - @elephant_estimates_by_country.each do |row|
-      tr style='height:18px' 
-        td
-          a href=("#{@country.gsub(' '),'_')}/#{row['OBJECTID']}" = row['survey_zone']
-        - if @year.to_i==2007
-          td= row['ReasonForChange']
-        td= row['method_and_quality']
-        td style="text-align:center" = row['CATEGORY']
-        td= row['CYEAR']
-        td.numeric= number_with_delimiter row['ESTIMATE']
-        td.numeric= number_with_delimiter row['CL95']
-        td style="padding-left:10px" = row['REFERENCE']
-        td style='text-align:center' = row['PFS']
-        td.numeric style="padding-right:10px" = number_with_delimiter row['AREA_SQKM']
-        td style='text-align:center' = row['LON']
-        td style='text-align:center' = row['LAT']
-
-p
-  | * Range of informed guess
-p
-  sup 1
-  | Key to Causes of Change (only tracked since 2007): DA: Different Area; DD: Data Degraded; DT: Different Technique; NA: New Analysis; NG: New Guess; NP: New population; PL: Population Lost; RS: Repeat Survey (RS ́ denotes a repeat survey that is not statistically comparable for reasons such as different season); –––: No Change
-p
-  sup 2
-  | Key to Survey Types: AC: Aerial Count, not specified; AS: Aerial Sample Count; AT: Aerial Total Count; DC: Dung Count; EX: Extrapolation from GIS; GD: Genetic Dung Count; GS: Ground Sample Count; GT: Ground Total Count; IG: Informed Guess; IR: Individual Registration; OG: Other Guess. Survey Type is followed by an indicator of survey quality, ranked from 1 to 3 (best to worst). Survey Reliability is keyed A-E (best to worst) as <a href='/reliability'>outlined in this table</a
-p
-  sup 3
-  | PFS: Priority for Future Surveys, ranked from 1 to 5 (highest to lowest). Based on the precision of estimates and the proportion of national range accounted for by the site in question, PFS is a measure of the importance and urgency for future population surveys. All areas of unassessed range have a priority of 1. See Introduction for details on how the PFS is derived.
-== footnote
+    p
+      | * Range of informed guess
+    p
+      sup 1
+      == t 'footnotes.causes_of_change'
+    p
+      sup 2
+      == t 'footnotes.survey_types'
+    p
+      sup 3
+      == t 'footnotes.pfs'
+    == footnote

--- a/app/views/report/index.html.slim
+++ b/app/views/report/index.html.slim
@@ -1,7 +1,9 @@
-h1 Explore by Species
+.row
+  .col-xs-12
+    h1 Explore by Species
 
-| Reports
+    | Reports
 
-div style='margin-top:20px' 
+    div style='margin-top:20px' 
 
-a href='report/Loxodonta_africana'  Loxodonta africana
+    a href='report/Loxodonta_africana'  Loxodonta africana

--- a/app/views/report/preview_continent.html.slim
+++ b/app/views/report/preview_continent.html.slim
@@ -1,196 +1,47 @@
-h1
-  div
-    | Continental Totals
-  div style=('font-size: 20px;')
-    = @preview_title
+.row
+  .col-xs-12
+    h1
+      div
+        | Continental Totals
+      div style=('font-size: 20px;')
+        = @preview_title
 
-.crumbs
-  a href='/report' Reports
+    = render 'preview_breadcrumbs'
 
-  | &gt;
+    p
+    ' All Years for #{@continent}:
+    a href=("/preview_report/2013_africa_final/#{@species.gsub(' ','_')}/2013/#{@continent}") 2013
 
-  a href="/report/#{@species.gsub(' ','_')}"
+    - @past_years.each do |year|
+      '
+      ' &mdash;
+      = link_to year, "/report/#{@species.gsub(' ','_')}/#{year}/#{@continent}"
 
-  = @species
+    == narrative
 
-  | &gt;
+    = render 'table_preview_summary_totals', level: @continent, totals: @summary_totals_by_continent, baselines: @baseline_total
 
-  = @year
+    - if current_user and current_user.admin?
+      = render 'table_causes_of_change', totals: @causes_of_change_by_continent_u, sums: @causes_of_change_sums_by_continent_u
 
-  | &gt;
+      = render 'table_causes_of_change', totals: @causes_of_change_by_continent, sums: @causes_of_change_sums_by_continent,
+        hideable: true,
+        title: 'Interpretation of Changes in Estimates from Previous Report (2007 Scaling)'
 
-  = @continent
+      .toggle style=('margin-top:-20px; margin-bottom: 10px; text-align: right')
+        a onclick='toggle_hideables()'  toggle scaling
 
-p
-| All Years for #{@continent}:
-a href=("/preview_report/2013_africa_final/#{@species.gsub(' ','_')}/2013/#{@continent}") 2013
+    = render 'table_area_of_range_covered', totals: @area_of_range_covered_by_continent, sums: @area_of_range_covered_sum_by_continent
 
-| &mdash;
+    = render 'table_continental_regional_data_quality', preview: true
 
-a href=("/report/#{@species.gsub(' ','_')}/2007/#{@continent}")  2007
+    == footnote
 
-| &mdash;
-
-a href=("/report/#{@species.gsub(' ','_')}/2002/#{@continent}")  2002
-
-| &mdash;
-
-a href=("/report/#{@species.gsub(' ','_')}/1998/#{@continent}")  1998
-
-| &mdash;
-
-a href=("/report/#{@species.gsub(' ','_')}/1995/#{@continent}")  1995
-
-== narrative
-
-- if @summary_totals_by_continent.num_tuples > 0
-  h2 style='margin-top:20px'
-    ' Summary Totals for
-    = @continent
-
-  table style='font-size:16px'
-    tr
-      th width='40%'  Data Category
-      th.numeric width='15%'  Definite
-      th.numeric width='15%'  Probable
-      th.numeric width='15%'  Possible
-      th.numeric width='15%'  Speculative
-    -@sdef = @sprob = @sposs = @sspec = 0
-    -@summary_totals_by_continent.each do |row|
-      tr style=('height: 24px')
-        td= row['SURVEYTYPE']
-        td.numeric= number_with_delimiter row['DEFINITE']
-        - @sdef = @sdef + row['DEFINITE'].to_i
-        td.numeric= number_with_delimiter row['PROBABLE']
-        - @sprob = @sprob + row['PROBABLE'].to_i
-        td.numeric= number_with_delimiter row['POSSIBLE']
-        - @sposs = @sposs + row['POSSIBLE'].to_i
-        td.numeric= number_with_delimiter row['SPECUL']
-        - @sspec = @sspec + row['SPECUL'].to_i
-    tr.totals style=('height: 24px; font-weight: bold')
-      td Totals # @year
-      td.numeric= number_with_delimiter @sdef
-      td.numeric= number_with_delimiter @sprob
-      td.numeric= number_with_delimiter @sposs
-      td.numeric= number_with_delimiter @sspec
-    - if @year==2013
-      -@baseline_total.each do |base|
-        tr.totals style=('height: 24px; font-style: italic;')
-          td Totals 2006
-          td.numeric= number_with_delimiter base['definite']
-          td.numeric= number_with_delimiter base['probable']
-          td.numeric= number_with_delimiter base['possible']
-          td.numeric= number_with_delimiter base['speculative']
-
-- if current_user and current_user.admin?
-  - if !@causes_of_change_by_continent_u.nil? && @causes_of_change_by_continent_u.num_tuples > 0
-    h2 Interpretation of Changes in Estimates from Previous Report
-
-    table style='font-size:16px'
-      tr
-        th width='40%'  Cause of Change
-        th.numeric width='15%'  Definite
-        th.numeric width='15%'  Probable
-        th.numeric width='15%'  Possible
-        th.numeric width='15%'  Speculative
-      - @causes_of_change_by_continent_u.each do |row|
-        tr style=('height: 24px;')
-          td= row['CauseofChange']
-          - ['definite','probable','possible','specul'].each do |key|
-            td.numeric= signed_number row[key]
-      - unless @causes_of_change_sums_by_continent_u.nil?
-        - @causes_of_change_sums_by_continent_u.each do |row|
-          tr.hideable.totals style=('height: 24px; font-weight: bold')
-            td Totals
-            - ['definite','probable','possible','specul'].each do |key|
-              td.numeric= signed_number row[key]
-
-  - if !@causes_of_change_by_continent.nil? && @causes_of_change_by_continent.num_tuples > 0
-    h2.hideable Interpretation of Changes in Estimates from Previous Report (2007 Scaling)
-
-    table.hideable style='font-size:16px'
-      tr
-        th width='40%'  Cause of Change
-        th.numeric width='15%'  Definite
-        th.numeric width='15%'  Probable
-        th.numeric width='15%'  Possible
-        th.numeric width='15%'  Speculative
-      - @causes_of_change_by_continent.each do |row|
-        tr style=('height: 24px;')
-          td= row['CauseofChange']
-          - ['definite','probable','possible','specul'].each do |key|
-            td.numeric= signed_number row[key]
-      - unless @causes_of_change_sums_by_continent.nil?
-        - @causes_of_change_sums_by_continent.each do |row|
-          tr.totals style=('height: 24px; font-weight: bold')
-            td Totals
-            - ['definite','probable','possible','specul'].each do |key|
-              td.numeric= signed_number row[key]
-
-  .toggle style=('margin-top:-20px; margin-bottom: 10px; text-align: right')
-    a onclick='toggle_hideables()'  toggle scaling
-
-- if !@area_of_range_covered_by_continent.nil? && @area_of_range_covered_by_continent.num_tuples > 0
-  h2 Area of Range Covered by Each Data Category (km²)
-  table style='font-size:16px'
-    tr
-      th Data Category
-      th.numeric Known Range
-      th.numeric Possible Range
-      th.numeric Total Range
-    - @area_of_range_covered_by_continent.each do |row|
-      tr style=('height: 24px;')
-        td= number_with_delimiter row['surveytype']
-        - ['known','possible','total'].each do |key|
-          td.numeric= number_or_zero row[key]
-    - @area_of_range_covered_sum_by_continent.each do |row|
-      tr.totals style=('height: 24px; font-weight: bold')
-        td Totals
-        - ['known','possible','total'].each do |key|
-          td.numeric= number_or_zero row[key]
-
-- if !@regions.nil? && @regions.num_tuples > 0
-  h2 Continental and Regional Totals and Data Quality
-  table style='font-size:16px'
-    tr
-      th Region
-      th.numeric Definite
-      th.numeric Probable
-      th.numeric Possible
-      th.numeric Speculative
-      th.numeric Range Area (km²)
-      th.numeric % of Continental Range
-      th.numeric % of Range Assessed
-      th.numeric
-        | IQI<sup>1</sup
-      th.numeric
-        | PFS<sup>2</sup
-    - @regions.each do |row|
-      - unless row['RANGEAREA'].nil?
-        tr style=('height: 24px;')
-          td
-            a href="/preview_report/#{@filter}/#{@species.gsub(' ','_')}/#{@year}/#{@continent}/#{row['REGION'].gsub(' ','_')}"
-              = row['REGION']
-          - ['DEFINITE','PROBABLE','POSSIBLE','SPECUL','RANGEAREA','RANGEPERC','SURVRANGPERC','INFQLTYIDX','PFS'].each do |key|
-            td.numeric= number_with_delimiter row[key]
-    - @regions_sum.each do |row|
-      tr.totals style=('height: 24px; font-weight: bold')
-        td Totals
-        - ['DEFINITE','PROBABLE','POSSIBLE','SPECUL','RANGEAREA','RANGEPERC','SURVRANGPERC','INFQLTYIDX'].each do |key|
-          td.numeric= number_with_delimiter row[key]
-        td
-
-== footnote
-
-p
-  sup 1
-  | IQI: Information Quality Index: This index quantifies overall data quality at the regional level based on the precision of estimates and the proportion of assessed elephant range (i.e. range for which estimates are available). The IQI ranges from zero (no reliable information) to one (perfect information).
-p
-  sup 2
-  | PFS: Priority for Future Surveys, ranked from 1 to 5 (highest to lowest). Based on the precision of estimates and the proportion of national range accounted for by the site in question, PFS is a measure of the importance and urgency for future population surveys. All areas of unassessed range have a priority of 1. See Introduction for details on how the PFS is derived.
-p
-  | Note that totals for the Definite, Probable, and Possible categories are derived
-  | by pooling the variances of individual estimates, as described at
-  = link_to 'http://www.elephantdatabase.org/reliability.', 'http://www.elephantdatabase.org/reliability'
-  | As a result, totals do not
-  | necessarily match the simple sum of the entries within a given category.
+    p
+      sup 1
+      == t 'footnotes.iqi'
+    p
+      sup 2
+      == t 'footnotes.pfs'
+    p
+      == t 'footnotes.derived_warning'

--- a/app/views/report/preview_country.html.slim
+++ b/app/views/report/preview_country.html.slim
@@ -1,302 +1,166 @@
-h1
-  div
-    = @country
-  div style=('font-size: 20px;')
-    = @preview_title
+.row
+  .col-xs-12
+    h1
+      div
+        = @country
+      div style=('font-size: 20px;')
+        = @preview_title
 
-.crumbs
-  | Reports
+    = render 'preview_breadcrumbs'
 
-  | &gt;
+    p
+    ' All Years for #{@country}:
 
-  a href=("/report/#{@species.gsub(' ','_')}")
-    = @species
+    a href=("/preview_report/2013_africa_final/#{@species.gsub(' ','_')}/2013/#{@continent}/#{@region.gsub(' ','_')}/#{@country.gsub(' ','_')}")
+      | 2013
 
-  | &gt;
+    - @past_years.each do |year|
+      '
+      ' &mdash;
+      = link_to year, "/report/#{@species.gsub(' ','_')}/#{year}/#{@continent}/#{@region.gsub(' ','_')}/#{@country.gsub(' ','_')}"
 
-  = @year
+    == narrative
 
-  | &gt;
+    = render 'table_preview_summary_totals', level: @country, totals: @summary_totals_by_country, baselines: @baseline_total
 
-  a href=("/preview_report/#{@filter}/#{@species.gsub(' ','_')}/#{@year}/#{@continent}")
-    = @continent
+    - if current_user and current_user.admin?
+      = render 'table_causes_of_change', totals: @causes_of_change_by_country_u, sums: @causes_of_change_sums_by_country_u
+      = render 'table_causes_of_change', totals: @causes_of_change_by_country, sums: @causes_of_change_sums_by_country,
+        hideable: true,
+        title: 'Interpretation of Changes in Estimates from Previous Report (2007 scaling)'
 
-  | &gt;
+      .toggle style=('margin-top:-20px; margin-bottom: 10px; text-align: right')
+        a onclick='toggle_hideables()'  toggle scaling
 
-  a href=("/preview_report/#{@filter}/#{@species.gsub(' ','_')}/#{@year}/#{@continent}/#{@region.gsub(' ','_')}")
-    = @region
+    = render 'table_area_of_range_covered', totals: @area_of_range_covered_by_country, sums: @area_of_range_covered_sum_by_country
 
-  | &gt;
+    - if @elephant_estimates_by_country.num_tuples > 0
+      h2
+        = @country
+        |: Elephant Estimates
+      table.table
+        tr
+          th style="border:none"
+            th style="border:none"  Cause of
+          th colspan=3 style="text-align:center"
+            | Survey Details
+            sup 2
+          th colspan=2 style="text-align:center"  Number of Elephants
+          th style="border:none"
+          th style="border:none"
+          th.numeric style=("border:none; padding-right:10px")  Area
+          th colspan=2 style="text-align:center"  Map Location
+        tr
+          th Input Zone
+          th
+            | Change
+            sup 1
+          th Type
+          th Reliab.
+          th Year
+          th.numeric Estimate
+          th.numeric 95% C.L.
+          th style="padding-left:10px"  Source
+          th
+            | PFS
+            sup 3
+          th.numeric style="padding-right:10px"  (km²)
+          th style='text-align:center'  Lon.
+          th style='text-align:center'  Lat.
+        - @elephant_estimate_groups.each do |group|
+          - @rn = @cc = @ty = @yr = @re = ''
+          - @ar = @n = @pv = @es = @cl = @car = @dp = @dpps = @ra = 0
+          - if group.size > 1
+            - group.each do |row|
+              - @rn = row['replacement_name']
+              - @cc = row['ReasonForChange']
+              - @ca = row['CATEGORY']
+              - @ty = row['method_and_quality'].gsub(/[\d]/,'')
+              - @yr = row['CYEAR']
+              - @re = row['REFERENCE']
+              - @dp = @dp + row['DP'].to_f
+              - @dpps = @dpps + row['DPPS'].to_f
+              - @car = @car + row['CALC_SQKM'].to_f
+              - @ar = @ar + row['AREA_SQKM'].to_i
+              - @pv = @pv + row['population_variance'].to_f
+              - @es = @es + row['ESTIMATE'].to_i
+              - @lo = row['LON']
+              - @la = row['LAT']
+              - @ra = row['RA'].to_f
+              - @n = @n + 1
+          - else
+            - group.each do |row|
+              - @rn = row['replacement_name']
+              - @cc = row['ReasonForChange']
+              - @ca = row['CATEGORY']
+              - @ty = row['method_and_quality'].gsub(/[\d]/,'')
+              - @yr = row['CYEAR']
+              - @re = row['REFERENCE']
+              - @dp = row['DP'].to_f
+              - @dpps = row['DPPS'].to_f
+              - @car = row['CALC_SQKM'].to_f
+              - @ar = row['AREA_SQKM']
+              - @pv = 0
+              - @cl = row['CL95']
+              - @es = row['ESTIMATE']
+              - @lo = row['LON']
+              - @la = row['LAT']
+              - @n = @n + 1
+              - @ra = row['RA'].to_f
+          - @pf = (Math.log10(((@dp+0.001)/(@dpps+0.001))+1/(@car/@ra))).round
+          tr
+            td
+              a href="javascript:toggle_section('#{@rn.gsub(/[^\w\d]/,'')}')" style='text-decoration:none'  +
+              = @rn
+            td= @cc
+            td= @ty
+            td style="text-align:center" = @ca
+            td= @yr
+            td style="text-align:right" = number_with_delimiter @es
+            -if @pv>0
+              td style="text-align:right" = number_with_delimiter ((Math.sqrt(@pv))*1.96).round
+            - else
+              td style="text-align:right" = @cl.to_s.gsub(/[^\d]/, "")!="0" ? number_with_delimiter(@cl) : ""
+            td style="padding-left:10px" = @re
+            td style="text-align:center" = @pf
+            td style="text-align:right" = @ar.to_s!="0" ? number_with_delimiter(@ar) : ""
+            td style="text-align:center" = @lo
+            td style="text-align:center" = @la
+          - group.each do |row|
+            tr style=('height:18px; display:none')
+              td
+                | &#160;
+                | &#160;
+                a href="/population_submissions/#{row['population_submission_id']}" != row['stratum_name']
+              td= row['ReasonForChange']
+              td= row['method_and_quality'].gsub(/[\d]/,'')
+              td style="text-align:center" = row['CATEGORY']
+              td= row['CYEAR']
+              td.numeric= number_with_delimiter row['ESTIMATE']
+              td.numeric= row['CL95'].to_s.gsub(/[^\d]/, '')!="0" ? (number_with_delimiter row['CL95']) : ""
+              td style="padding-left:10px" = row['REFERENCE']
+              td style='text-align:center' = row['PFS']
+              td.numeric style="padding-right:10px" = number_with_delimiter row['AREA_SQKM']
+              td style='text-align:center' = row['LON']
+              td style='text-align:center' = row['LAT']
 
-  #{@country}
+    == footnote
 
-p
-| All Years for #{@country}:
+    p
+      | * Range of informed guess
+    p
+      sup 1
+      == t 'footnotes.causes_of_change'
+    p
+      sup 2
+      == t 'footnotes.survey_types'
+    p
+      sup 3
+      == t 'footnotes.pfs'
+    p
+      == t 'footnotes.derived_warning'
 
-a href=("/preview_report/2013_africa_final/#{@species.gsub(' ','_')}/2013/#{@continent}/#{@region.gsub(' ','_')}/#{@country.gsub(' ','_')}")
-  | 2013
-
-| &mdash;
-
-a href=("/report/#{@species.gsub(' ','_')}/2007/#{@continent}/#{@region.gsub(' ','_')}/#{@country.gsub(' ','_')}")
-  | 2007
-
-| &mdash;
-
-a href=("/report/#{@species.gsub(' ','_')}/2002/#{@continent}/#{@region.gsub(' ','_')}/#{@country.gsub(' ','_')}")
-  | 2002
-
-| &mdash;
-
-a href=("/report/#{@species.gsub(' ','_')}/1998/#{@continent}/#{@region.gsub(' ','_')}/#{@country.gsub(' ','_')}")
-  | 1998
-
-| &mdash;
-
-a href=("/report/#{@species.gsub(' ','_')}/1995/#{@continent}/#{@region.gsub(' ','_')}/#{@country.gsub(' ','_')}")
-  | 1995
-
-== narrative
-
-- if @summary_totals_by_country.num_tuples > 0
-  h2 style=('margin-top:20px')
-    ' Summary Totals for
-    = @country
-
-  table style='font-size:16px'
-    tr
-      th width='40%'  Data Category
-      th.numeric width='15%'  Definite
-      th.numeric width='15%'  Probable
-      th.numeric width='15%'  Possible
-      th.numeric width='15%'  Speculative
-    -@sdef = @sprob = @sposs = @sspec = 0
-    -@summary_totals_by_country.each do |row|
-      tr style=('height: 24px')
-        td= row['SURVEYTYPE']
-        td.numeric= number_with_delimiter row['DEFINITE']
-        - @sdef = @sdef + row['DEFINITE'].to_i
-        td.numeric= number_with_delimiter row['PROBABLE']
-        - @sprob = @sprob + row['PROBABLE'].to_i
-        td.numeric= number_with_delimiter row['POSSIBLE']
-        - @sposs = @sposs + row['POSSIBLE'].to_i
-        td.numeric= number_with_delimiter row['SPECUL']
-        - @sspec = @sspec + row['SPECUL'].to_i
-    tr.totals style=('height: 24px; font-weight: bold')
-      td
-        ' Totals
-        = @year
-      td.numeric= number_with_delimiter @sdef
-      td.numeric= number_with_delimiter @sprob
-      td.numeric= number_with_delimiter @sposs
-      td.numeric= number_with_delimiter @sspec
-    - if @year==2013
-      -@baseline_total.each do |base|
-        tr.totals style=('height: 24px; font-style: italic;')
-          td Totals 2006
-          td.numeric= number_with_delimiter base['definite']
-          td.numeric= number_with_delimiter base['probable']
-          td.numeric= number_with_delimiter base['possible']
-          td.numeric= number_with_delimiter base['speculative']
-
-- else
-  h2 No estimates were available for # @country} in #{@year
-- if current_user and current_user.admin?
-  - if !@causes_of_change_by_country_u.nil? && @causes_of_change_by_country_u.num_tuples > 0
-    h2 Interpretation of Changes in Estimates from Previous Report
-
-    table style='font-size:16px'
-      tr
-        th width='40%'  Cause of Change
-        th.numeric width='15%'  Definite
-        th.numeric width='15%'  Probable
-        th.numeric width='15%'  Possible
-        th.numeric width='15%'  Speculative
-      - @causes_of_change_by_country_u.each do |row|
-        tr style=('height: 24px;')
-          td= row['CauseofChange']
-          - ['definite','probable','possible','specul'].each do |key|
-            td.numeric= signed_number row[key]
-      - unless @causes_of_change_sums_by_country_u.nil?
-        - @causes_of_change_sums_by_country_u.each do |row|
-          tr.hideable.totals style=('height: 24px; font-weight: bold')
-            td Totals
-            - ['definite','probable','possible','specul'].each do |key|
-              td.numeric= signed_number row[key]
-  - if !@causes_of_change_by_country_u.nil? && @causes_of_change_by_country_u.num_tuples > 0
-    h2.hideable Interpretation of Changes in Estimates from Previous Report (2007 scaling)
-
-    table.hideable style='font-size:16px'
-      tr
-        th width='40%'  Cause of Change
-        th.numeric width='15%'  Definite
-        th.numeric width='15%'  Probable
-        th.numeric width='15%'  Possible
-        th.numeric width='15%'  Speculative
-      - @causes_of_change_by_country.each do |row|
-        tr style=('height: 24px;')
-          td= row['CauseofChange']
-          - ['definite','probable','possible','specul'].each do |key|
-            td.numeric= signed_number row[key]
-      - unless @causes_of_change_sums_by_country.nil?
-        - @causes_of_change_sums_by_country.each do |row|
-          tr.totals style=('height: 24px; font-weight: bold')
-            td Totals
-            - ['definite','probable','possible','specul'].each do |key|
-              td.numeric= signed_number row[key]
-  .toggle style=('margin-top:-20px; margin-bottom: 10px; text-align: right')
-    a onclick='toggle_hideables()'  toggle scaling
-
-- if !@area_of_range_covered_by_country.nil? && @area_of_range_covered_by_country.num_tuples > 0
-  h2 Area of Range Covered by Each Data Category (km²)
-  table style='font-size:16px'
-    tr
-      th Data Category
-      th.numeric Known Range
-      th.numeric Possible Range
-      th.numeric Total Range
-    - @area_of_range_covered_by_country.each do |row|
-      tr style=('height: 24px;')
-        td= number_with_delimiter row['surveytype']
-        - ['known','possible','total'].each do |key|
-          td.numeric= number_or_zero row[key]
-    - @area_of_range_covered_sum_by_country.each do |row|
-      tr.totals style=('height: 24px; font-weight: bold')
-        td Totals
-        - ['known','possible','total'].each do |key|
-          td.numeric= number_or_zero row[key]
-
-- if @elephant_estimates_by_country.num_tuples > 0
-  h2
-    = @country
-    |: Elephant Estimates
-  table
-    tr
-      th style="border:none"
-        th style="border:none"  Cause of
-      th colspan=3 style="text-align:center"
-        | Survey Details
-        sup 2
-      th colspan=2 style="text-align:center"  Number of Elephants
-      th style="border:none"
-      th style="border:none"
-      th.numeric style=("border:none; padding-right:10px")  Area
-      th colspan=2 style="text-align:center"  Map Location
-    tr
-      th Input Zone
-      th
-        | Change
-        sup 1
-      th Type
-      th Reliab.
-      th Year
-      th.numeric Estimate
-      th.numeric 95% C.L.
-      th style="padding-left:10px"  Source
-      th
-        | PFS
-        sup 3
-      th.numeric style="padding-right:10px"  (km²)
-      th style='text-align:center'  Lon.
-      th style='text-align:center'  Lat.
-    - @elephant_estimate_groups.each do |group|
-      - @rn = @cc = @ty = @yr = @re = ''
-      - @ar = @n = @pv = @es = @cl = @car = @dp = @dpps = @ra = 0
-      - if group.size > 1
-        - group.each do |row|
-          - @rn = row['replacement_name']
-          - @cc = row['ReasonForChange']
-          - @ca = row['CATEGORY']
-          - @ty = row['method_and_quality'].gsub(/[\d]/,'')
-          - @yr = row['CYEAR']
-          - @re = row['REFERENCE']
-          - @dp = @dp + row['DP'].to_f
-          - @dpps = @dpps + row['DPPS'].to_f
-          - @car = @car + row['CALC_SQKM'].to_f
-          - @ar = @ar + row['AREA_SQKM'].to_i
-          - @pv = @pv + row['population_variance'].to_f
-          - @es = @es + row['ESTIMATE'].to_i
-          - @lo = row['LON']
-          - @la = row['LAT']
-          - @ra = row['RA'].to_f
-          - @n = @n + 1
-      - else
-        - group.each do |row|
-          - @rn = row['replacement_name']
-          - @cc = row['ReasonForChange']
-          - @ca = row['CATEGORY']
-          - @ty = row['method_and_quality'].gsub(/[\d]/,'')
-          - @yr = row['CYEAR']
-          - @re = row['REFERENCE']
-          - @dp = row['DP'].to_f
-          - @dpps = row['DPPS'].to_f
-          - @car = row['CALC_SQKM'].to_f
-          - @ar = row['AREA_SQKM']
-          - @pv = 0
-          - @cl = row['CL95']
-          - @es = row['ESTIMATE']
-          - @lo = row['LON']
-          - @la = row['LAT']
-          - @n = @n + 1
-          - @ra = row['RA'].to_f
-      - @pf = (Math.log10(((@dp+0.001)/(@dpps+0.001))+1/(@car/@ra))).round
-      tr
-        td
-          a href="javascript:toggle_section('#{@rn.gsub(/[^\w\d]/,'')}')" style='text-decoration:none'  +
-          = @rn
-        td= @cc
-        td= @ty
-        td style="text-align:center" = @ca
-        td= @yr
-        td style="text-align:right" = number_with_delimiter @es
-        -if @pv>0
-          td style="text-align:right" = number_with_delimiter ((Math.sqrt(@pv))*1.96).round
-        - else
-          td style="text-align:right" = @cl.to_s.gsub(/[^\d]/, "")!="0" ? number_with_delimiter(@cl) : ""
-        td style="padding-left:10px" = @re
-        td style="text-align:center" = @pf
-        td style="text-align:right" = @ar.to_s!="0" ? number_with_delimiter(@ar) : ""
-        td style="text-align:center" = @lo
-        td style="text-align:center" = @la
-      - group.each do |row|
-        tr style=('height:18px; display:none')
-          td
-            | &#160;
-            | &#160;
-            a href="/population_submissions/#{row['population_submission_id']}" != row['stratum_name']
-          td= row['ReasonForChange']
-          td= row['method_and_quality'].gsub(/[\d]/,'')
-          td style="text-align:center" = row['CATEGORY']
-          td= row['CYEAR']
-          td.numeric= number_with_delimiter row['ESTIMATE']
-          td.numeric= row['CL95'].to_s.gsub(/[^\d]/, '')!="0" ? (number_with_delimiter row['CL95']) : ""
-          td style="padding-left:10px" = row['REFERENCE']
-          td style='text-align:center' = row['PFS']
-          td.numeric style="padding-right:10px" = number_with_delimiter row['AREA_SQKM']
-          td style='text-align:center' = row['LON']
-          td style='text-align:center' = row['LAT']
-
-== footnote
-
-p
-  | * Range of informed guess
-p
-  sup 1
-  | Key to Causes of Change (only tracked since 2007): DA: Different Area; DD: Data Degraded; DT: Different Technique; NA: New Analysis; NG: New Guess; NP: New population; PL: Population Lost; RS: Repeat Survey (RS ́ denotes a repeat survey that is not statistically comparable for reasons such as different season); –––: No Change
-p
-  sup 2
-  | Key to Survey Types: AC: Aerial Count, not specified; AS: Aerial Sample Count; AT: Aerial Total Count; DC: Dung Count; EX: Extrapolation from GIS; GD: Genetic Dung Count; GS: Ground Sample Count; GT: Ground Total Count; IG: Informed Guess; IR: Individual Registration; OG: Other Guess. Survey Type is followed by an indicator of survey quality, ranked from 1 to 3 (best to worst). Survey Reliability is keyed A-E (best to worst) as <a href='/reliability'>outlined in this table</a
-p
-  sup 3
-  | PFS: Priority for Future Surveys, ranked from 1 to 5 (highest to lowest). Based on the precision of estimates and the proportion of national range accounted for by the site in question, PFS is a measure of the importance and urgency for future population surveys. All areas of unassessed range have a priority of 1. See Introduction for details on how the PFS is derived.
-p
-  | Note that totals for the Definite, Probable, and Possible categories are derived
-  | by pooling the variances of individual estimates, as described at
-  = link_to 'http://www.elephantdatabase.org/reliability.', 'http://www.elephantdatabase.org/reliability'
-  | As a result, totals do not
-  | necessarily match the simple sum of the entries within a given category.
-
-javascript:
-  | function toggle_section(key){
-    | jQuery('*[data-section="'+key+'"]').toggle(300)
-  | }
+    javascript:
+      function toggle_section(key){
+        jQuery('*[data-section="'+key+'"]').toggle(300)
+      }

--- a/app/views/report/preview_region.html.slim
+++ b/app/views/report/preview_region.html.slim
@@ -1,199 +1,48 @@
-h1
-  div
-    = @region
-  div style=('font-size: 20px;')
-    = @preview_title
+.row
+  .col-xs-12
+    h1
+      div
+        = @region
+      div style=('font-size: 20px;')
+        = @preview_title
 
-.crumbs
-  a href='/report'
-  ' Reports
+    = render 'preview_breadcrumbs'
 
-  ' &gt;
+    p
+    ' All Years for #{@region}:
 
-  a href="/report/#{@species.gsub(' ','_')}"
-    = @species
+    a href=("/preview_report/2013_africa/#{@species.gsub(' ','_')}/2013/#{@continent}/#{@region.gsub(' ','_')}")  2013
 
-  '  &gt;
+    - @past_years.each do |year|
+      '
+      ' &mdash;
+      = link_to year, "/report/#{@species.gsub(' ','_')}/#{year}/#{@continent}/#{@region.gsub(' ','_')}"
 
-  = @year
+    == narrative
 
-  '  &gt;
+    = render 'table_preview_summary_totals', level: @region, totals: @summary_totals_by_region, baselines: @baseline_total
 
-  a href=("/preview_report/#{@filter}/#{@species.gsub(' ','_')}/#{@year}/#{@continent}")
-    = @continent
+    - if current_user and current_user.admin?
+      = render 'table_causes_of_change', totals: @causes_of_change_by_region_u, sums: @causes_of_change_sums_by_region_u
 
-  '  &gt;
+      = render 'table_causes_of_change', totals: @causes_of_change_by_region, sums: @causes_of_change_sums_by_region, 
+        hideable: true,
+        title: "Interpretation of Changes in Estimates from Previous Report (2007 Scaling)"
 
-  = @region
+      .toggle style=('margin-top:-20px; margin-bottom: 10px; text-align: right')
+        a onclick='toggle_hideables()'  toggle scaling
 
-p
-' All Years for #{@region}:
+    = render 'table_area_of_range_covered', totals: @area_of_range_covered_by_region, sums: @area_of_range_covered_sum_by_region
 
-a href=("/preview_report/2013_africa/#{@species.gsub(' ','_')}/2013/#{@continent}/#{@region.gsub(' ','_')}")  2013
+    = render 'table_country_regional_data_quality', preview: true
 
-' &mdash;
+    == footnote
 
-a href=("/report/#{@species.gsub(' ','_')}/2007/#{@continent}/#{@region.gsub(' ','_')}") 2007
-
-' &mdash;
-
-a href=("/report/#{@species.gsub(' ','_')}/2002/#{@continent}/#{@region.gsub(' ','_')}") 2002
-
-' &mdash;
-
-a href=("/report/#{@species.gsub(' ','_')}/1998/#{@continent}/#{@region.gsub(' ','_')}") 1998
-
-' &mdash;
-
-a href=("/report/#{@species.gsub(' ','_')}/1995/#{@continent}/#{@region.gsub(' ','_')}") 1995
-
-== narrative
-
-- if @summary_totals_by_region.num_tuples > 0
-  h2 style=('margin-top:20px')
-    ' Summary Totals for
-    = @region
-
-  table style='font-size:16px'
-    tr
-      th width='40%'  Data Category
-      th.numeric width='15%'  Definite
-      th.numeric width='15%'  Probable
-      th.numeric width='15%'  Possible
-      th.numeric width='15%'  Speculative
-    -@sdef = @sprob = @sposs = @sspec = 0
-    -@summary_totals_by_region.each do |row|
-      tr style=('height: 24px')
-        td= row['SURVEYTYPE']
-        td.numeric= number_with_delimiter row['DEFINITE']
-        - @sdef = @sdef + row['DEFINITE'].to_i
-        td.numeric= number_with_delimiter row['PROBABLE']
-        - @sprob = @sprob + row['PROBABLE'].to_i
-        td.numeric= number_with_delimiter row['POSSIBLE']
-        - @sposs = @sposs + row['POSSIBLE'].to_i
-        td.numeric= number_with_delimiter row['SPECUL']
-        - @sspec = @sspec + row['SPECUL'].to_i
-    tr.totals style=('height: 24px; font-weight: bold')
-      td Totals # @year
-      td.numeric= number_with_delimiter @sdef
-      td.numeric= number_with_delimiter @sprob
-      td.numeric= number_with_delimiter @sposs
-      td.numeric= number_with_delimiter @sspec
-    - if @year==2013
-      -@baseline_total.each do |base|
-        tr.totals style=('height: 24px; font-style: italic;')
-          td Totals 2006
-          td.numeric= number_with_delimiter base['definite']
-          td.numeric= number_with_delimiter base['probable']
-          td.numeric= number_with_delimiter base['possible']
-          td.numeric= number_with_delimiter base['speculative']
-
-- if current_user and current_user.admin?
-  - if !@causes_of_change_by_region_u.nil? && @causes_of_change_by_region_u.num_tuples > 0
-    h2 Interpretation of Changes in Estimates from Previous Report
-
-    table style='font-size:16px'
-      tr
-        th width='40%'  Cause of Change
-        th.numeric width='15%'  Definite
-        th.numeric width='15%'  Probable
-        th.numeric width='15%'  Possible
-        th.numeric width='15%'  Speculative
-      - @causes_of_change_by_region_u.each do |row|
-        tr style=('height: 24px;')
-          td= row['CauseofChange']
-          - ['definite','probable','possible','specul'].each do |key|
-            td.numeric= signed_number row[key]
-      - unless @causes_of_change_sums_by_region_u.nil?
-        - @causes_of_change_sums_by_region_u.each do |row|
-          tr.hideable.totals style=('height: 24px; font-weight: bold')
-            td Totals
-            - ['definite','probable','possible','specul'].each do |key|
-              td.numeric= signed_number row[key]
-
-  - if !@causes_of_change_by_region.nil? && @causes_of_change_by_region.num_tuples > 0
-    h2.hideable Interpretation of Changes in Estimates from Previous Report (2007 Scaling)
-
-    table.hideable style='font-size:16px'
-      tr
-        th width='40%'  Cause of Change
-        th.numeric width='15%'  Definite
-        th.numeric width='15%'  Probable
-        th.numeric width='15%'  Possible
-        th.numeric width='15%'  Speculative
-      - @causes_of_change_by_region.each do |row|
-        tr style=('height: 24px;')
-          td= row['CauseofChange']
-          - ['definite','probable','possible','specul'].each do |key|
-            td.numeric= signed_number row[key]
-      - unless @causes_of_change_sums_by_region.nil?
-        - @causes_of_change_sums_by_region.each do |row|
-          tr.totals style=('height: 24px; font-weight: bold')
-            td Totals
-            - ['definite','probable','possible','specul'].each do |key|
-              td.numeric= signed_number row[key]
-
-  .toggle style=('margin-top:-20px; margin-bottom: 10px; text-align: right')
-    a onclick='toggle_hideables()'  toggle scaling
-
-- if !@area_of_range_covered_by_region.nil? && @area_of_range_covered_by_region.num_tuples > 0
-  h2 Area of Range Covered by Each Data Category (km²)
-  table style='font-size:16px'
-    tr
-      th Data Category
-      th.numeric Known Range
-      th.numeric Possible Range
-      th.numeric Total Range
-    - @area_of_range_covered_by_region.each do |row|
-      tr style=('height: 24px;')
-        td= number_with_delimiter row['surveytype']
-        - ['known','possible','total'].each do |key|
-          td.numeric= number_or_zero row[key]
-    - @area_of_range_covered_sum_by_region.each do |row|
-      tr.totals style=('height: 24px; font-weight: bold')
-        td Totals
-        - ['known','possible','total'].each do |key|
-          td.numeric= number_or_zero row[key]
-
-- if !@countries.nil? && @countries.num_tuples > 0
-  h2 Country and Regional Totals and Data Quality
-  table style='font-size:16px'
-    tr
-      th Country
-      th.numeric Definite
-      th.numeric Probable
-      th.numeric Possible
-      th.numeric Speculative
-      th.numeric Range Area (km²)
-      th.numeric % of Regional Range
-      th.numeric % of Range Assessed
-      th.numeric IQI<sup>1</sup
-      th.numeric PFS<sup>2</sup
-    - @countries.each do |row|
-      - unless row['RANGEAREA'].nil?
-        tr style=('height: 24px;')
-          td
-            a href=("#{@region.gsub(' ','_')}/#{u row['CNTRYNAME'].gsub(' ','_')}")
-              = row['CNTRYNAME']
-          - ['DEFINITE','PROBABLE','POSSIBLE','SPECUL','RANGEAREA','RANGEPERC','SURVRANGPERC','INFQLTYIDX','PFS'].each do |key|
-            td.numeric= number_with_delimiter row[key]
-    - @countries_sum.each do |row|
-      tr.totals style=('height: 24px; font-weight: bold')
-        td Totals
-        - ['DEFINITE','PROBABLE','POSSIBLE','SPECUL','RANGEAREA','RANGEPERC','SURVRANGPERC','INFQLTYIDX','PFS'].each do |key|
-          td.numeric= number_with_delimiter row[key]
-
-== footnote
-
-p
-  sup 1
-  | IQI: Information Quality Index: This index quantifies overall data quality at the regional level based on the precision of estimates and the proportion of assessed elephant range (i.e. range for which estimates are available). The IQI ranges from zero (no reliable information) to one (perfect information).
-p
-  sup 2
-  | PFS: Priority for Future Surveys, ranked from 1 to 5 (highest to lowest). Based on the precision of estimates and the proportion of national range accounted for by the site in question, PFS is a measure of the importance and urgency for future population surveys. All areas of unassessed range have a priority of 1. See Introduction for details on how the PFS is derived.
-p
-  | Note that totals for the Definite, Probable, and Possible categories are derived
-  | by pooling the variances of individual estimates, as described at
-  = link_to 'http://www.elephantdatabase.org/reliability.', 'http://www.elephantdatabase.org/reliability'
-  | As a result, totals do not
-  | necessarily match the simple sum of the entries within a given category.
+    p
+      sup 1
+      == t 'footnotes.iqi'
+    p
+      sup 2
+      == t 'footnotes.pfs'
+    p
+      == t 'footnotes.derived_warning'

--- a/app/views/report/preview_site.html.slim
+++ b/app/views/report/preview_site.html.slim
@@ -1,170 +1,113 @@
-h1
-  div
-    = @site
-  div style=('font-size: 20px;') 
-    = @preview_title
+.row
+  .col-xs-12
+    h1
+      div
+        = @site
+      div style=('font-size: 20px;') 
+        = @preview_title
 
-.crumbs
-  | Reports
+    = render 'preview_breadcrumbs'
 
-  | &gt;
+    .crumbs
+      | Reports
 
-  a href=("/report/#{@species.gsub(' '),'_')}"} #{@species 
+      | &gt;
 
-  | &gt;
+      a href=("/report/#{@species.gsub(' '),'_')}"} #{@species 
 
-  = @preview_nav
+      | &gt;
 
-  | &gt;
+      = @preview_nav
 
-  a href=("/preview_report/#{@filter}/#{@species.gsub(' '),'_')}/#{@year}/#{@continent}"} #{@continent 
+      | &gt;
 
-  | &gt;
+      a href=("/preview_report/#{@filter}/#{@species.gsub(' ','_')}/#{@year}/#{@continent}") @continent 
 
-  | Site
+      | &gt;
 
-  | &gt;
+      | Site
 
-  #{@site}
+      | &gt;
 
-  p
+      = @site
 
-/!
+      p
 
-  | All Years for #{@site}:
+    /!
 
-  a href=("/preview_report/#{@filter}/#{@species.gsub(' '),'_')}/2007/#{@continent}/site/#{@site}"  2007
+      | All Years for #{@site}:
 
-  | &mdash;
+      a href=("/preview_report/#{@filter}/#{@species.gsub(' '),'_')}/2007/#{@continent}/site/#{@site}"  2007
 
-  a href=("/preview_report/#{@filter}/#{@species.gsub(' '),'_')}/2011/#{@continent}/site/#{@site}"  2011
+      | &mdash;
 
-== narrative
+      a href=("/preview_report/#{@filter}/#{@species.gsub(' '),'_')}/2011/#{@continent}/site/#{@site}"  2011
 
-- if @summary_totals_by_site.num_tuples > 0
-  h2 style=('margin-top:20px'} Summary Totals for #{@site) 
+    == narrative
 
-  table style='font-size:16px' 
-    tr
-      th width='40%'  Data Category
-      th.numeric width='15%'  Definite
-      th.numeric width='15%'  Probable
-      th.numeric width='15%'  Possible
-      th.numeric width='15%'  Speculative
-    -@summary_totals_by_site.each do |row|
-      tr style=('height: 24px') 
-        td= row['SURVEYTYPE']
-        td.numeric= number_with_delimiter row['DEFINITE']
-        td.numeric= number_with_delimiter row['PROBABLE']
-        td.numeric= number_with_delimiter row['POSSIBLE']
-        td.numeric= number_with_delimiter row['SPECUL']
-    -@summary_sums_by_site.each do |row|
-      tr.totals style=('height: 24px; font-weight: bold') 
-        td Totals # @year 
-        td.numeric= number_with_delimiter row['DEFINITE']
-        td.numeric= number_with_delimiter row['PROBABLE']
-        td.numeric= number_with_delimiter row['POSSIBLE']
-        td.numeric= number_with_delimiter row['SPECUL']
-- else
-  h2 No estimates were available for # @site} in #{@year 
-- if !@causes_of_change_by_site.nil? && @causes_of_change_by_site.num_tuples > 0
-  h2 Interpretation of Changes in Estimates from Previous Report
+    = render 'table_summary_totals', level: @site, totals: @summary_totals_by_site, sums: @summary_sums_by_site
 
-  table style='font-size:16px' 
-    tr
-      th width='40%'  Cause of Change
-      th.numeric width='15%'  Definite
-      th.numeric width='15%'  Probable
-      th.numeric width='15%'  Possible
-      th.numeric width='15%'  Speculative
-    - @causes_of_change_by_site.each do |row|
-      tr style=('height: 24px;') 
-        td= row['CauseofChange']
-        - ['definite','probable','possible','specul'].each do |key|
-          td.numeric= signed_number row[key]
-    - unless @causes_of_change_sums_by_site.nil?
-      - @causes_of_change_sums_by_site.each do |row|
-        tr.totals style=('height: 24px; font-weight: bold') 
-          td Totals
-          - ['definite','probable','possible','specul'].each do |key|
-            td.numeric= signed_number row[key]
+    = render 'table_causes_of_change', totals: @causes_of_change_by_site, sums: @causes_of_change_sums_by_site
 
-- if !@area_of_range_covered_by_site.nil? && @area_of_range_covered_by_site.num_tuples > 0
-  h2 Area of Range Covered by Each Data Category (km²)
-  table style='font-size:16px' 
-    tr
-      th Data Category
-      th.numeric Known Range
-      th.numeric Possible Range
-      th.numeric Total Range
-    - @area_of_range_covered_by_site.each do |row|
-      tr style=('height: 24px;') 
-        td= number_with_delimiter row['surveytype']
-        - ['known','possible','total'].each do |key|
-          td.numeric= number_or_zero row[key]
-    - @area_of_range_covered_sum_by_site.each do |row|
-      tr.totals style=('height: 24px; font-weight: bold') 
-        td Totals
-        - ['known','possible','total'].each do |key|
-          td.numeric= number_or_zero row[key]
+    = render 'table_area_of_range_covered', totals: @area_of_range_covered_by_site, sums: @area_of_range_covered_sum_by_site
 
-- if @elephant_estimates_by_site.num_tuples > 0
-  h2 # @site : Elephant Estimates
-  table
-    tr
-      th style="border:none" 
-        th style="border:none"  Cause of
-      th colspan=3 style="text-align:center" 
-        | Survey Details
-        sup 2
-      th colspan=2 style="text-align:center"  Number of Elephants
-      th style="border:none" 
-      th style="border:none" 
-      th.numeric style=("border:none; padding-right:10px")  Area
-      th colspan=2 style="text-align:center"  Map Location
-    tr
-      th Input Zone
-      th
-        | Change
-        sup 1
-      th Type
-      th Reliab.
-      th Year
-      th.numeric Estimate
-      th.numeric 95% C.L.
-      th style="padding-left:10px"  Source
-      th
-        | PFS
-        sup 3
-      th.numeric style="padding-right:10px"  (km²)
-      th style='text-align:center'  Lon.
-      th style='text-align:center'  Lat.
-    - @elephant_estimates_by_site.each do |row|
-      tr style='height:18px' 
-        td
-          a href="/population_submissions/#{row['population_submission_id']}" != row['survey_zone']
-        td= row['ReasonForChange']
-        td= row['method_and_quality'].gsub(/[\d]/,'')
-        td style="text-align:center" = row['CATEGORY']
-        td= row['CYEAR']
-        td.numeric= number_with_delimiter row['ESTIMATE']
-        td.numeric= number_with_delimiter row['CL95']
-        td style="padding-left:10px" = row['REFERENCE']
-        td style='text-align:center' = row['PFS']
-        td.numeric style="padding-right:10px" = number_with_delimiter row['AREA_SQKM']
-        td style='text-align:center' = row['LON']
-        td style='text-align:center' = row['LAT']
+    - if @elephant_estimates_by_site.num_tuples > 0
+      h2 #{@site} : Elephant Estimates
+      table.table
+        tr
+          th style="border:none" 
+            th style="border:none"  Cause of
+          th colspan=3 style="text-align:center" 
+            | Survey Details
+            sup 2
+          th colspan=2 style="text-align:center"  Number of Elephants
+          th style="border:none" 
+          th style="border:none" 
+          th.numeric style=("border:none; padding-right:10px")  Area
+          th colspan=2 style="text-align:center"  Map Location
+        tr
+          th Input Zone
+          th
+            | Change
+            sup 1
+          th Type
+          th Reliab.
+          th Year
+          th.numeric Estimate
+          th.numeric 95% C.L.
+          th style="padding-left:10px"  Source
+          th
+            | PFS
+            sup 3
+          th.numeric style="padding-right:10px"  (km²)
+          th style='text-align:center'  Lon.
+          th style='text-align:center'  Lat.
+        - @elephant_estimates_by_site.each do |row|
+          tr style='height:18px' 
+            td
+              a href="/population_submissions/#{row['population_submission_id']}" != row['survey_zone']
+            td= row['ReasonForChange']
+            td= row['method_and_quality'].gsub(/[\d]/,'')
+            td style="text-align:center" = row['CATEGORY']
+            td= row['CYEAR']
+            td.numeric= number_with_delimiter row['ESTIMATE']
+            td.numeric= number_with_delimiter row['CL95']
+            td style="padding-left:10px" = row['REFERENCE']
+            td style='text-align:center' = row['PFS']
+            td.numeric style="padding-right:10px" = number_with_delimiter row['AREA_SQKM']
+            td style='text-align:center' = row['LON']
+            td style='text-align:center' = row['LAT']
 
-== footnote
+    == footnote
 
-p
-  | * Range of informed guess
-p
-  sup 1
-  | Key to Causes of Change (only tracked since 2007): DA: Different Area; DD: Data Degraded; DT: Different Technique; NA: New Analysis; NG: New Guess; NP: New population; PL: Population Lost; RS: Repeat Survey (RS ́ denotes a repeat survey that is not statistically comparable for reasons such as different season); –––: No Change
-p
-  sup 2
-  | Key to Survey Types: AC: Aerial Count, not specified; AS: Aerial Sample Count; AT: Aerial Total Count; DC: Dung Count; EX: Extrapolation from GIS; GD: Genetic Dung Count; GS: Ground Sample Count; GT: Ground Total Count; IG: Informed Guess; IR: Individual Registration; OG: Other Guess. Survey Type is followed by an indicator of survey quality, ranked from 1 to 3 (best to worst). Survey Reliability is keyed A-E (best to worst) as <a href='/reliability'>outlined in this table</a
-p
-  sup 3
-  | PFS: Priority for Future Surveys, ranked from 1 to 5 (highest to lowest). Based on the precision of estimates and the proportion of national range accounted for by the site in question, PFS is a measure of the importance and urgency for future population surveys. All areas of unassessed range have a priority of 1. See Introduction for details on how the PFS is derived.
+    p
+      | * Range of informed guess
+    p
+      sup 1
+      == t 'footnotes.causes_of_change'
+    p
+      sup 2
+      == t 'footnotes.survey_types'
+    p
+      sup 3
+      == t 'footnotes.pfs'

--- a/app/views/report/references.html.slim
+++ b/app/views/report/references.html.slim
@@ -1,7 +1,9 @@
-h1 Bibliography: African Elephant Status Reports
-- @i = 0
-- @references.each do |reference|
-  - @i = @i + 1
-  p
-    == format_reference reference
+.row
+  .col-xs-12
+    h1 Bibliography: African Elephant Status Reports
+    - @i = 0
+    - @references.each do |reference|
+      - @i = @i + 1
+      p
+        == format_reference reference
 

--- a/app/views/report/region.html.slim
+++ b/app/views/report/region.html.slim
@@ -1,143 +1,34 @@
-h1 # @year} Regional Totals for #{@region 
-a href='/report' Reports
+.row
+  .col-xs-12
+    h1 = "#{@year} Regional Totals for #{@region}"
 
-| &gt;
+    = render 'breadcrumbs'
 
-a href=("/report/#{@species.gsub(' '),'_')}"} #{@species 
+    p
+    ' All Years for #{@region}:
 
-| &gt;
+    a href=("/preview_report/2013_africa_final/#{@species.gsub(' ','_')}/2013/#{@continent}/#{@region.gsub(' ','_')}")  2013
 
-a href=("/report/#{@species.gsub(' '),'_')}/#{@year}"} #{@year 
+    - @past_years.each do |year|
+      '
+      ' &mdash;
+      = link_to year, "/report/#{@species.gsub(' ','_')}/#{year}/#{@continent}/#{@region.gsub(' ','_')}"
 
-| &gt;
+    == narrative
 
-a href=("/report/#{@species.gsub(' '),'_')}/#{@year}/#{@continent}"} #{@continent 
+    = render 'table_summary_totals', level: @region, totals: @summary_totals_by_region, sums: @summary_sums_by_region
 
-| &gt;
+    = render 'table_causes_of_change', totals: @causes_of_change_by_region, sums: @causes_of_change_sums_by_region
 
-#{@region}
+    = render 'table_area_of_range_covered', totals: @area_of_range_covered_by_region, sums: @area_of_range_covered_sum_by_region
 
-p
-| All Years for #{@region}:
+    = render 'table_country_regional_data_quality'
 
-a href=("/preview_report/2013_africa_final/#{@species.gsub(' '),'_')}/2013/#{@continent}/#{@region.gsub(' ','_')}"  2013
+    p
+      sup 1
+      == t 'footnotes.iqi'
+    p
+      sup 2
+      == t 'footnotes.pfs'
 
-| &mdash;
-
-a href=("/report/#{@species.gsub(' '),'_')}/2007/#{@continent}/#{@region.gsub(' ','_')}"  2007
-
-| &mdash;
-
-a href=("/report/#{@species.gsub(' '),'_')}/2002/#{@continent}/#{@region.gsub(' ','_')}"  2002
-
-| &mdash;
-
-a href=("/report/#{@species.gsub(' '),'_')}/1998/#{@continent}/#{@region.gsub(' ','_')}"  1998
-
-| &mdash;
-
-a href=("/report/#{@species.gsub(' '),'_')}/1995/#{@continent}/#{@region.gsub(' ','_')}"  1995
-
-== narrative
-
-- if @summary_totals_by_region.num_tuples > 0
-  h2 style=('margin-top:20px'} #{@year} Summary Totals for #{@region) 
-
-  table style='font-size:16px' 
-    tr
-      th width='40%'  Data Category
-      th.numeric width='15%'  Definite
-      th.numeric width='15%'  Probable
-      th.numeric width='15%'  Possible
-      th.numeric width='15%'  Speculative
-    -@summary_totals_by_region.each do |row|
-      tr style=('height: 24px') 
-        td= row['SURVEYTYPE']
-        td.numeric= number_with_delimiter row['DEFINITE']
-        td.numeric= number_with_delimiter row['PROBABLE']
-        td.numeric= number_with_delimiter row['POSSIBLE']
-        td.numeric= number_with_delimiter row['SPECUL']
-    -@summary_sums_by_region.each do |row|
-      tr.totals style=('height: 24px; font-weight: bold') 
-        td Totals # @year 
-        td.numeric= number_with_delimiter row['DEFINITE']
-        td.numeric= number_with_delimiter row['PROBABLE']
-        td.numeric= number_with_delimiter row['POSSIBLE']
-        td.numeric= number_with_delimiter row['SPECUL']
-
-- if !@causes_of_change_by_region.nil? && @causes_of_change_by_region.num_tuples > 0
-  h2 Interpretation of Changes in Estimates from Previous Report
-
-  table style='font-size:16px' 
-    tr
-      th width='40%'  Cause of Change
-      th.numeric width='15%'  Definite
-      th.numeric width='15%'  Probable
-      th.numeric width='15%'  Possible
-      th.numeric width='15%'  Speculative
-    - @causes_of_change_by_region.each do |row|
-      tr style=('height: 24px;') 
-        td= row['CauseofChange']
-        - ['definite','probable','possible','specul'].each do |key|
-          td.numeric= signed_number row[key]
-    - unless @causes_of_change_sums_by_region.nil?
-      - @causes_of_change_sums_by_region.each do |row|
-        tr.totals style=('height: 24px; font-weight: bold') 
-          td Totals
-          - ['definite','probable','possible','specul'].each do |key|
-            td.numeric= signed_number row[key]
-
-- if !@area_of_range_covered_by_region.nil? && @area_of_range_covered_by_region.num_tuples > 0
-  h2 Area of Range Covered by Each Data Category (km²)
-  table style='font-size:16px' 
-    tr
-      th Data Category
-      th.numeric Known Range
-      th.numeric Possible Range
-      th.numeric Total Range
-    - @area_of_range_covered_by_region.each do |row|
-      tr style=('height: 24px;') 
-        td= number_with_delimiter row['surveytype']
-        - ['known','possible','total'].each do |key|
-          td.numeric= number_or_zero row[key]
-    - @area_of_range_covered_sum_by_region.each do |row|
-      tr.totals style=('height: 24px; font-weight: bold') 
-        td Totals
-        - ['known','possible','total'].each do |key|
-          td.numeric= number_or_zero row[key]
-
-- if !@countries.nil? && @countries.num_tuples > 0
-  h2 Country and Regional Totals and Data Quality
-  table style='font-size:16px' 
-    tr
-      th Country
-      th.numeric Definite
-      th.numeric Probable
-      th.numeric Possible
-      th.numeric Speculative
-      th.numeric Range Area (km²)
-      th.numeric % of Regional Range
-      th.numeric % of Range Assessed
-      th.numeric IQI<sup>1</sup
-      th.numeric PFS<sup>2</sup
-    - @countries.each do |row|
-      - unless row['RANGEAREA'].nil?
-        tr style=('height: 24px;') 
-          td
-            a href=("#{@region.gsub(' '),'_')}/#{u row['CNTRYNAME'].gsub(' ','_')}"} #{row['CNTRYNAME'] 
-          - ['DEFINITE','PROBABLE','POSSIBLE','SPECUL','RANGEAREA','RANGEPERC','SURVRANGPERC','INFQLTYIDX','PFS'].each do |key|
-            td.numeric= number_with_delimiter row[key]
-    - @countries_sum.each do |row|
-      tr.totals style=('height: 24px; font-weight: bold') 
-        td Totals
-        - ['DEFINITE','PROBABLE','POSSIBLE','SPECUL','RANGEAREA','RANGEPERC','SURVRANGPERC','INFQLTYIDX','PFS'].each do |key|
-          td.numeric= number_with_delimiter row[key]
-
-p
-  sup 1
-  | IQI: Information Quality Index: This index quantifies overall data quality at the regional level based on the precision of estimates and the proportion of assessed elephant range (i.e. range for which estimates are available). The IQI ranges from zero (no reliable information) to one (perfect information).
-p
-  sup 2
-  | PFS: Priority for Future Surveys, ranked from 1 to 5 (highest to lowest). Based on the precision of estimates and the proportion of national range accounted for by the site in question, PFS is a measure of the importance and urgency for future population surveys. All areas of unassessed range have a priority of 1. See Introduction for details on how the PFS is derived.
-
-== footnote
+    == footnote

--- a/app/views/report/species.html.slim
+++ b/app/views/report/species.html.slim
@@ -1,90 +1,33 @@
-h1
-  | Available Reports for
-  em # @species 
+.row
+  .col-xs-12
+    h1
+      | Available Reports for
+      em #{@species}
 
-a href='/report' Reports
+    = render 'breadcrumbs'
 
-| &gt;
+    div style=('margin-top: 20px') 
+    .want_data
+      strong Want data?
+      br
+      | Request to download
+      br
+      | data <a href="/data_request_forms/new">here.</a>
 
-#{@species}
+    -['2013'].each do |r|
+      .report_cover
+        = link_to "/preview_report/2013_africa_final/Loxodonta_africana/2013/Africa" do
+          = image_tag "aesr#{r}_cover_150w.png"
+        .more
+          = link_to "/preview_report/2013_africa_final/Loxodonta_africana/2013/Africa" do
+            h5 Provisional African Elephant Population Estimates: update to 31 Dec 2013
+          .authors IUCN African Elephant Specialist Group
 
-div style=('margin-top: 20px') 
-.want_data
-  | <strong>Want data?</strong><br /
-  | Request to download<br/
-  | data <a href="/data_request_forms/new">here.</a
-
--['2013'].each do |r|
-  .report_cover
-    = link_to "/preview_report/2013_africa_final/Loxodonta_africana/2013/Africa" do
-      = image_tag "aesr#{r}_cover_150w.png"
-    .more
-      = link_to "/preview_report/2013_africa_final/Loxodonta_africana/2013/Africa" do
-        | <h5>Provisional African Elephant Population Estimates: update to 31 Dec 2013</h5
-      .authors IUCN African Elephant Specialist Group
+    - @past_reports.each do |report|
+      = render 'yearly_status', report
 
 
--['2007'].each do |r|
-  .report_cover
-    = link_to "/report/#{@species.gsub(' ','_')}/#{r}" do
-      = image_tag "aesr#{r}_cover_150w.png"
-    .more
-      = link_to "/report/#{@species.gsub(' ','_')}/#{r}" do
-        | <h5>#{r} African Elephant Status Report</h5
-      .authors J.J. Blanc, R.F.W. Barnes, G.C. Craig, H.T. Dublin, C.R. Thouless, I. Douglas-Hamilton, and J.A. Hart
-      .links
-        | Explore the <a href="http://african-elephant.org/aed/aesr2007.html" target="_blank">full text of the 2007 report</a> (PDF) and its
-        =link_to "/report/#{@species.gsub(' ','_')}/#{r}" do
-          | errata
-        | or
-        =link_to 'bibliography', '/report/references'
-
--['2002'].each do |r|
-  .report_cover
-    = link_to "/report/#{@species.gsub(' ','_')}/#{r}" do
-      = image_tag "aesr#{r}_cover_150w.png"
-    .more
-      = link_to "/report/#{@species.gsub(' ','_')}/#{r}" do
-        | <h5>#{r} African Elephant Status Report</h5
-      .authors J.J. Blanc, C.R. Thouless, J.A. Hart, H.T. Dublin, I. Douglas-Hamilton, G.C. Craig and R.F.W. Barnes
-      .links
-        | Explore the <a href="http://african-elephant.org/aed/aesr2002.html" target="_blank">full text of the 2002 report</a> (PDF) and its
-        =link_to "/report/#{@species.gsub(' ','_')}/#{r}" do
-          | errata
-        | or
-        =link_to 'bibliography', '/report/references'
-
--['1998'].each do |r|
-  .report_cover
-    = link_to "/report/#{@species.gsub(' ','_')}/#{r}" do
-      = image_tag "aesr#{r}_cover_150w.png"
-    .more
-      = link_to "/report/#{@species.gsub(' ','_')}/#{r}" do
-        | <h5>#{r} African Elephant Status Report</h5
-      .authors R.F.W. Barnes, G.C. Craig, H.T. Dublin, G. Overton, W. Simons and C.R. Thouless
-      .links
-      | Explore the <a href="http://african-elephant.org/aed/aed98.html" target="_blank">full text of the 1998 report</a> (PDF) and its
-      =link_to "/report/#{@species.gsub(' ','_')}/#{r}" do
-        | errata
-      | or
-      =link_to 'bibliography', '/report/references'
-
--['1995'].each do |r|
-  .report_cover
-    = link_to "/report/#{@species.gsub(' ','_')}/#{r}" do
-      = image_tag "aesr#{r}_cover_150w.png"
-    .more
-      = link_to "/report/#{@species.gsub(' ','_')}/#{r}" do
-        | <h5>#{r} African Elephant Status Report</h5
-      .authors M.Y. Said, R.N. Chunge, G.C. Craig, C.R. Thouless, R.F.W. Barnes and H.T. Dublin
-      .links
-        | Explore the <a href="http://african-elephant.org/aed/aed95.html" target="_blank">full text of the 1995 report</a> (PDF) and its
-        =link_to "/report/#{@species.gsub(' ','_')}/#{r}" do
-          | errata
-        | or
-        =link_to 'bibliography', '/report/references'
-
-p
-p
-p
-p
+    p
+    p
+    p
+    p

--- a/app/views/report/survey.html.slim
+++ b/app/views/report/survey.html.slim
@@ -1,66 +1,44 @@
-h1 # @survey_zone['survey_zone']} #{@survey_zone['designate'] 
+.row
+  .col-xs-12
+    h1 = "#{@survey_zone['survey_zone']} #{@survey_zone['designate']}"
 
-| Reports
+    = render 'breadcrumbs'
 
-| &gt;
+    div style=('margin-top: 20px') 
 
-a href=("/report/#{@species.gsub(' '),'_')}"} #{@species 
+    iframe style='float:right' width='400px' height='400px' src="https://www.google.com/fusiontables/embedviz?viz=MAP&q=select+col4+from+2896260+where+col2+%3D+'#{@survey_zone['OBJECTID']}'&h=false&lat=#{@survey_zone['numeric_lat']}&lng=#{@survey_zone['numeric_lon']}&z=8&t=4&l=col4" 
+    div style=('font-size: 40px; font-weight: bold') 
+      =number_with_delimiter @survey_zone['ESTIMATE']
+    div style=('font-size: 20px;') 
+      | elephants in #{@survey_zone['CYEAR']}
+    div style=('margin-top: 20px;') 
+      | Source:
+      =@survey_zone['REFERENCE']
+    div
+      | Area surveyed:
+      =number_with_delimiter @survey_zone['AREA_SQKM']
+      | km²
+    div
+      | Location:
+      = @survey_zone['LON']
+      | ,
+      = @survey_zone['LAT']
 
-| &gt;
+    div style=('margin-top: 40px; width: 300px; padding: 20px; background: #ccc') 
+      div style=('margin-bottom: 10px') 
+        strong
+          | Analysis by AfESG
+      div
+        | Cause of change:
+        =@survey_zone['ReasonForChange']
+      div
+        | Type and Quality:
+        =@survey_zone['method_and_quality']
+      div
+        | Reliability:
+        =@survey_zone['CATEGORY']
+      div
+        | Priority for Future Surveys:
+        =@survey_zone['PFS']
 
-a href=("/report/#{@species.gsub(' '),'_')}/#{@year}"} #{@year 
-
-| &gt;
-
-a href=("/report/#{@species.gsub(' '),'_')}/#{@year}/#{@continent}"} #{@continent 
-
-| &gt;
-
-a href=("/report/#{@species.gsub(' '),'_')}/#{@year}/#{@continent}/#{@region.gsub(' ','_')}"} #{@region 
-
-| &gt;
-
-a href=("/report/#{@species.gsub(' '),'_')}/#{@year}/#{@continent}/#{@region.gsub(' ','_')}/#{@country.gsub(' ','_')}"} #{@country 
-
-| &gt;
-
-#{@survey_zone['survey_zone']} #{@survey_zone['designate']}
-
-div style=('margin-top: 20px') 
-
-iframe style='float:right' width='400px' height='400px' src="https://www.google.com/fusiontables/embedviz?viz=MAP&q=select+col4+from+2896260+where+col2+%3D+'#{@survey_zone['OBJECTID']}'&h=false&lat=#{@survey_zone['numeric_lat']}&lng=#{@survey_zone['numeric_lon']}&z=8&t=4&l=col4" 
-div style=('font-size: 40px; font-weight: bold') 
-  =number_with_delimiter @survey_zone['ESTIMATE']
-div style=('font-size: 20px;') 
-  | elephants in #{@survey_zone['CYEAR']}
-div style=('margin-top: 20px;') 
-  | Source:
-  =@survey_zone['REFERENCE']
-div
-  | Area surveyed:
-  =number_with_delimiter @survey_zone['AREA_SQKM']
-  | km²
-div
-  | Location:
-  = @survey_zone['LON']
-  | ,
-  = @survey_zone['LAT']
-
-div style=('margin-top: 40px; width: 300px; padding: 20px; background: #ccc') 
-  div style=('margin-bottom: 10px') 
-    strong
-      | Analysis by AfESG
-  div
-    | Cause of change:
-    =@survey_zone['ReasonForChange']
-  div
-    | Type and Quality:
-    =@survey_zone['method_and_quality']
-  div
-    | Reliability:
-    =@survey_zone['CATEGORY']
-  div
-    | Priority for Future Surveys:
-    =@survey_zone['PFS']
-
-div style='clear:both' 
+    div style='clear:both' 

--- a/app/views/report/year.html.slim
+++ b/app/views/report/year.html.slim
@@ -1,71 +1,65 @@
-h1 African Elephant Status Report # @year 
+.row
+  .col-xs-12
+    h1 African Elephant Status Report #{@year}
 
-a href='/report' Reports
+    = render 'breadcrumbs'
 
-| &gt;
+    div style='margin-top:20px' 
 
-a href=("/report/#{@species.gsub(' '),'_')}"} #{@species 
-
-| &gt;
-
-#{@year}
-
-div style='margin-top:20px' 
-
-a href=("/report/#{@species.gsub(' '),'_')}/#{@year}/Africa"  Continental totals for Africa
-- if @year.to_i==2007
-  p
-  .errata
-    | The 2007 African Elephant Status Report contained a number of errata.  These have been fixed in the display of data found on www.elephantdatabase.org, but for the purposes of clarity, they are briefly outlined below.
-    p
-    ol
-      li
-        | Range figures for the following input zones are incorrect:
-        ul
+    a href=("/report/#{@species.gsub(' ','_')}/#{@year}/Africa")  Continental totals for Africa
+    - if @year.to_i==2007
+      p
+      .errata
+        | The 2007 African Elephant Status Report contained a number of errata.  These have been fixed in the display of data found on www.elephantdatabase.org, but for the purposes of clarity, they are briefly outlined below.
+        p
+        ol
           li
-            em Rest of Gabon Forest Range
-            | (page 64);
+            | Range figures for the following input zones are incorrect:
+            ul
+              li
+                em Rest of Gabon Forest Range
+                | (page 64);
+              li
+                em Rest of Northern Botswana
+                | (page 124); and
+              li
+                em Zambezia Province
+                | (page 134).
           li
-            em Rest of Northern Botswana
-            | (page 124); and
+            | Source for input zone
+            em Queen Elizabeth Conservation Area
+            | should be
+            em Wanyama, 2006
+            | (page 108). The reference was also omitted on page 256 and should read:
+            ul
+              li
+                | Wanyama, F. (2006). Queen Elizabeth National Park Wildlife Census Report, July 2006, Uganda, Kampala: Uganda Wildlife Authority.
           li
-            em Zambezia Province
-            | (page 134).
-      li
-        | Source for input zone
-        em Queen Elizabeth Conservation Area
-        | should be
-        em Wanyama, 2006
-        | (page 108). The reference was also omitted on page 256 and should read:
-        ul
+            | Cause of change for input zone
+            em Tekezze Valley Wildlife Reserve
+            | is ‘NA’, resulting in slightly adjusted numbers in the
+            em Ethiopia Interpretation of Changes in Estimates from Previous Report
+            | table (pages 77-78).
           li
-            | Wanyama, F. (2006). Queen Elizabeth National Park Wildlife Census Report, July 2006, Uganda, Kampala: Uganda Wildlife Authority.
-      li
-        | Cause of change for input zone
-        em Tekezze Valley Wildlife Reserve
-        | is ‘NA’, resulting in slightly adjusted numbers in the
-        em Ethiopia Interpretation of Changes in Estimates from Previous Report
-        | table (pages 77-78).
-      li
-        em Munyawama Game Reserve
-        | was inadvertently omitted from the input zones in South Africa (page 146).  This has been rectified and slightly impacts the South Africa national-level totals (page 145), the Southern Africa regional-level totals (page 113), as well as the interpretation of changes at these three levels.
-      li
-        | An error in assignment of the cause of change for the Luiana East and West Partial Reserves (page 120) slightly impacts the interpretation of changes for Angola (page 119), Southern Africa (page 113) and the continent (page 23).
-- if @year.to_i==2002
-  p
-  .errata
-    | The 2002 African Elephant Status Report contained an erratum.  This has been fixed in the display of data found on www.elephantdatabase.org, but for the purposes of clarity, it is briefly outlined below.
-    p
-    ol
-      li
-        | The continental summary totals (page 19) are incorrectly displayed.  The numbers that appear in the detail cells under POSSIBLE should be under PROBABLE, and vice versa. The totals row is correct.
-- if @year.to_i==1995
-  p
-  .errata
-    | The 1995 African Elephant Status Report contained a number of errata.  These have been fixed in the display of data found on www.elephantdatabase.org, but for the purposes of clarity, they are briefly outlined below.
-    p
-    ol
-      li
-        | The summary totals for Ghana as reflected in the West Africa sub-regional table on page 157 are incorrect.  The numbers as reflected in the Ghana summary on page 173 are correct.
-      li
-        | Additional small inconsistencies in both range and summary totals have been corrected in the display of data found on www.elephantdatabase.org.
+            em Munyawama Game Reserve
+            | was inadvertently omitted from the input zones in South Africa (page 146).  This has been rectified and slightly impacts the South Africa national-level totals (page 145), the Southern Africa regional-level totals (page 113), as well as the interpretation of changes at these three levels.
+          li
+            | An error in assignment of the cause of change for the Luiana East and West Partial Reserves (page 120) slightly impacts the interpretation of changes for Angola (page 119), Southern Africa (page 113) and the continent (page 23).
+    - if @year.to_i==2002
+      p
+      .errata
+        | The 2002 African Elephant Status Report contained an erratum.  This has been fixed in the display of data found on www.elephantdatabase.org, but for the purposes of clarity, it is briefly outlined below.
+        p
+        ol
+          li
+            | The continental summary totals (page 19) are incorrectly displayed.  The numbers that appear in the detail cells under POSSIBLE should be under PROBABLE, and vice versa. The totals row is correct.
+    - if @year.to_i==1995
+      p
+      .errata
+        | The 1995 African Elephant Status Report contained a number of errata.  These have been fixed in the display of data found on www.elephantdatabase.org, but for the purposes of clarity, they are briefly outlined below.
+        p
+        ol
+          li
+            | The summary totals for Ghana as reflected in the West Africa sub-regional table on page 157 are incorrect.  The numbers as reflected in the Ghana summary on page 173 are correct.
+          li
+            | Additional small inconsistencies in both range and summary totals have been corrected in the display of data found on www.elephantdatabase.org.

--- a/app/views/report_narratives/edit.html.slim
+++ b/app/views/report_narratives/edit.html.slim
@@ -1,11 +1,13 @@
-h1 Narratives and Footnotes
-p
-  = link_to 'All narratives and footnotes', report_narratives_path
-= semantic_form_for @report_narrative do |f|
-  = f.inputs do
-    = f.input :uri
-    = f.input :narrative
-    = f.input :footnote
+.row
+  .col-xs-12
+    h1 Narratives and Footnotes
+    p
+      = link_to 'All narratives and footnotes', report_narratives_path
+    = semantic_form_for @report_narrative do |f|
+      = f.inputs do
+        = f.input :uri
+        = f.input :narrative
+        = f.input :footnote
 
-  = f.buttons do
-    = f.commit_button
+      = f.actions do
+        = f.action :submit

--- a/app/views/report_narratives/index.html.slim
+++ b/app/views/report_narratives/index.html.slim
@@ -1,15 +1,17 @@
-h1 All Narratives and Footnotes
+.row
+  .col-xs-12
+    h1 All Narratives and Footnotes
 
-table
-  thead
-    tr
-      th= ReportNarrative.human_attribute_name :uri
-      th colspan=3 = t 'actions'
+    table.table
+      thead
+        tr
+          th= ReportNarrative.human_attribute_name :uri
+          th colspan=3 = t 'actions'
 
-  tbody
-    - for report_narrative in @report_narratives
-      tr  class=cycle(:odd, :even)  
-        td= report_narrative.uri
-        td.action= link_to t('show'), report_narrative
-        td.action= link_to t('edit'), edit_report_narrative_path(report_narrative)
-        td.action= link_to t('destroy'), report_narrative, :confirm => t('are_you_sure'), :method => :delete
+      tbody
+        - for report_narrative in @report_narratives
+          tr  class=cycle(:odd, :even)  
+            td= report_narrative.uri
+            td.action= link_to t('show'), report_narrative
+            td.action= link_to t('edit'), edit_report_narrative_path(report_narrative)
+            td.action= link_to t('destroy'), report_narrative, :confirm => t('are_you_sure'), :method => :delete

--- a/app/views/report_narratives/new.html.slim
+++ b/app/views/report_narratives/new.html.slim
@@ -1,10 +1,12 @@
-h1= t '.title'
-p= link_to t('back'), report_narratives_path
-= semantic_form_for @report_narrative do |f|
-  = f.inputs do
-    = f.input :uri, :as => 'hidden', :value => params[:uri]
-    = f.input :narrative
-    = f.input :footnote
+.row
+  .col-xs-12
+    h1= t '.title'
+    p= link_to t('back'), report_narratives_path
+    = semantic_form_for @report_narrative do |f|
+      = f.inputs do
+        = f.input :uri, :as => 'hidden', :value => params[:uri]
+        = f.input :narrative
+        = f.input :footnote
 
-  = f.buttons do
-    = f.commit_button
+      = f.actions do
+        = f.action :submit

--- a/app/views/report_narratives/show.html.slim
+++ b/app/views/report_narratives/show.html.slim
@@ -1,13 +1,15 @@
-h1= t '.title'
-p
-  = link_to t('back'), report_narratives_path
-  = link_to t('edit'), edit_report_narrative_path(@report_narrative)
-  = link_to t('.new'), new_report_narrative_path
+.row
+  .col-xs-12
+    h1= t '.title'
+    p
+      = link_to t('back'), report_narratives_path
+      = link_to t('edit'), edit_report_narrative_path(@report_narrative)
+      = link_to t('.new'), new_report_narrative_path
 
-dl
-  dt= ReportNarrative.human_attribute_name :uri
-  dd= @report_narrative.uri
-  dt= ReportNarrative.human_attribute_name :narrative
-  dd= @report_narrative.narrative
-  dt= ReportNarrative.human_attribute_name :footnote
-  dd= @report_narrative.footnote
+    dl
+      dt= ReportNarrative.human_attribute_name :uri
+      dd= @report_narrative.uri
+      dt= ReportNarrative.human_attribute_name :narrative
+      dd= @report_narrative.narrative
+      dt= ReportNarrative.human_attribute_name :footnote
+      dd= @report_narrative.footnote

--- a/app/views/submission_search/index.html.slim
+++ b/app/views/submission_search/index.html.slim
@@ -1,65 +1,64 @@
-.container
-  .row
-    .col-xs-12
-      h1 Submissions search form
+.row
+  .col-xs-12
+    h1 Submissions search form
 
-  form action="submission_search" class='form-inline'
-    .row
-      div class="form-group"
-        label
-          ' Country
-        select name='country' class='form-control'
-          - Country.where("is_surveyed=true").order(:name).each do |country|
-            - if country.id.to_s == params[:country]
-              option value=country.id selected='selected'
-                = country.name
-            - else
-              option value=country.id
-                = country.name
-      div class="form-group"
-        label
-          ' Survey Year
-        select name='survey_year' class='form-control'
-          - 2002.upto(2013).each do |year|
-            - if year.to_s == params[:survey_year]
-              option value=year selected='selected'
-                = year
-            - else
-              option value=year
-                = year
-      - if user_signed_in? && current_user.admin?
-        div class="form-group"
-          label
-            ' Released
-          input name='released' type='radio' value='true' checked='checked'
-            ' Yes
-          input name='released' type='radio' value='false'
-            ' No
-    .row
-      .col-xs-12 style='text-align:center'
-        input type='submit' value='Search' class='btn btn-primary'
+form action="submission_search" class='form-inline'
   .row
-    .col-xs-12
-      - if @search_results
-        table class='table table-responsive table-striped'
-          tr
-            th Site Name
-            th Survey Type
-            th Source
-            th Estimate
-            - if user_signed_in? && current_user.admin?
-              th Released
-              th Data Licensing
-              th Submitter
-          - @search_results.each do |result|
-              tr
-                td
-                  = link_to "/population_submissions/#{result['population_submission_id']}" do
-                    = result['site_name']
-                td= result['survey_type']
-                td= result['short_citation']
-                td= result['estimate']
-                - if user_signed_in? && current_user.admin?
-                  td= result['released']
-                  td= result['data_licensing']
-                  td= result['name']
+    div class="form-group"
+      label
+        ' Country
+      select name='country' class='form-control'
+        - Country.where("is_surveyed=true").order(:name).each do |country|
+          - if country.id.to_s == params[:country]
+            option value=country.id selected='selected'
+              = country.name
+          - else
+            option value=country.id
+              = country.name
+    div class="form-group"
+      label
+        ' Survey Year
+      select name='survey_year' class='form-control'
+        - 2002.upto(2013).each do |year|
+          - if year.to_s == params[:survey_year]
+            option value=year selected='selected'
+              = year
+          - else
+            option value=year
+              = year
+    - if user_signed_in? && current_user.admin?
+      div class="form-group"
+        label
+          ' Released
+        input name='released' type='radio' value='true' checked='checked'
+          ' Yes
+        input name='released' type='radio' value='false'
+          ' No
+  .row
+    .col-xs-12 style='text-align:center'
+      input type='submit' value='Search' class='btn btn-primary'
+.row
+  .col-xs-12
+    - if @search_results
+      table.table.table-responsive.table-striped
+        tr
+          th Site Name
+          th Survey Type
+          th Source
+          th Estimate
+          - if user_signed_in? && current_user.admin?
+            th Released
+            th Data Licensing
+            th Submitter
+        - @search_results.each do |result|
+            tr
+              td
+                = link_to "/population_submissions/#{result['population_submission_id']}" do
+                  = result['site_name']
+              td= result['survey_type']
+              td= result['short_citation']
+              td= result['estimate']
+              - if user_signed_in? && current_user.admin?
+                td= result['released']
+                td= result['data_licensing']
+                td= result['name']

--- a/app/views/submissions/_form.html.slim
+++ b/app/views/submissions/_form.html.slim
@@ -1,49 +1,52 @@
-.restated_survey_info
-  = render :partial => "submission_info", :locals => { :s => @submission }
-= semantic_form_for @submission do |f|
-  = render "shared/error_messages", :target => @submission
-  = f.inputs do
-    = f.input :species, :as => :select, :collection => Species.order(:id), :member_label => :scientific_name
-    = f.input :country, :as => :select, :collection => @submission.range_states
-    = f.input :phenotype, :as => :select, :collection => ["Savanna", "Forest", "Both", "Unknown"]
-    = f.input :phenotype_basis, :as => :select, :collection => ["Genetic evidence gathered on-site", "Appearance of elephants", "Geographical location", "Habitat"]
-    = f.input :data_type, :as => :hidden, :value => 'Population estimate'
-    = f.input :right_to_grant_permission, :required => true, :as => :radio, :collection => {"Yes, I have the right to grant permission to IUCN to use the data as specified" => true, "No, I do not have the right to grant permission, please email the following person:" => false}
-    = f.input :permission_email, :as => :email
-  = f.actions
+.row
+  .col-xs-12
+    h1 = @title
+    .restated_survey_info
+      = render :partial => "submission_info", :locals => { :s => @submission }
+    = semantic_form_for @submission do |f|
+      = render "shared/error_messages", :target => @submission
+      = f.inputs do
+        = f.input :species, :as => :select, :collection => Species.order(:id), :member_label => :scientific_name
+        = f.input :country, :as => :select, :collection => @submission.range_states
+        = f.input :phenotype, :as => :select, :collection => ["Savanna", "Forest", "Both", "Unknown"]
+        = f.input :phenotype_basis, :as => :select, :collection => ["Genetic evidence gathered on-site", "Appearance of elephants", "Geographical location", "Habitat"]
+        = f.input :data_type, :as => :hidden, :value => 'Population estimate'
+        = f.input :right_to_grant_permission, :required => true, :as => :radio, :collection => {"Yes, I have the right to grant permission to IUCN to use the data as specified" => true, "No, I do not have the right to grant permission, please email the following person:" => false}
+        = f.input :permission_email, :as => :email
+      = f.actions
 
-javascript:
-  | var load_species = function(){
-    | var species_id = this.value;
-    | $('#submission_country_id').html('');
-    | $.ajax({
-      | dataType: "jsonp",
-      | url: '/species/'+species_id+"/range_states.js",
-      | success: function (range_states) {
-        | if(range_states.length<1){
-          | alert("No range states found for that species.")
-        | } else {
-          | for(var i=0; i<range_states.length; i++){
-            | $('#submission_country_id').append('<option value="'+range_states[i].id+'">'+range_states[i].name+'</option>')
-          | }
-        | }
-      | },
-      | failure: function () {
-        | alert("Server error retrieving range states.");
-      | }
-    | });
-  | }
+    javascript:
+      var load_species = function(){
+        var species_id = this.value;
+        $('#submission_country_id').html('');
+        $.ajax({
+          dataType: "jsonp",
+          url: '/species/'+species_id+"/range_states.js",
+          success: function (range_states) {
+            if(range_states.length<1){
+              alert("No range states found for that species.")
+            } else {
+              for(var i=0; i<range_states.length; i++){
+                $('#submission_country_id').append('<option value="'+range_states[i].id+'">'+range_states[i].name+'</option>')
+              }
+            }
+          },
+          failure: function () {
+            alert("Server error retrieving range states.");
+          }
+        });
+      }
 
-  | $('#submission_species_id').change(load_species);
+      $('#submission_species_id').change(load_species);
 
-  | function hide_and_show_things(){
-    | $('#submission_right_to_grant_permission_false').each(function(){
-      | if(this.checked == true){
-        | $('#submission_permission_email_input').show()
-      | } else {
-        | $('#submission_permission_email_input').hide()
-      | }
-    | })
-  | }
-  | $('input[type=radio]').change(hide_and_show_things);
-  | hide_and_show_things();
+      function hide_and_show_things(){
+        $('#submission_right_to_grant_permission_false').each(function(){
+          if(this.checked == true){
+            $('#submission_permission_email_input').show()
+          } else {
+            $('#submission_permission_email_input').hide()
+          }
+        })
+      }
+      $('input[type=radio]').change(hide_and_show_things);
+      hide_and_show_things();

--- a/app/views/submissions/edit.html.slim
+++ b/app/views/submissions/edit.html.slim
@@ -1,5 +1,2 @@
-.container
-  .row
-    .col-xs-12
-      h1= t '.title'
-      = render 'form'
+- @title = t '.title'
+= render 'form'

--- a/app/views/submissions/index.html.slim
+++ b/app/views/submissions/index.html.slim
@@ -1,35 +1,37 @@
-h1= t('.title')
+.row
+  .col-xs-12
+    h1= t('.title')
 
-table
-  thead
-    tr
-      th= sortable 'user', 'User'
-      th= sortable 'site_name', 'Site Name'
-      th= sortable 'country', 'Country'
-      th= sortable 'phenotype', 'Phenotype'
-      th Pop
-      th Rng
-      th= sortable 'right_to_grant_permission', 'Perm'
-      th= sortable 'submitted', 'Submitted'
-      th= sortable 'released', 'Released'
-      th= sortable 'created_at', 'Created'
-      th= sortable 'updated_at', 'Updated'
-      th colspan=3 = t 'actions'
+    table.table
+      thead
+        tr
+          th= sortable 'user', 'User'
+          th= sortable 'site_name', 'Site Name'
+          th= sortable 'country', 'Country'
+          th= sortable 'phenotype', 'Phenotype'
+          th Pop
+          th Rng
+          th= sortable 'right_to_grant_permission', 'Perm'
+          th= sortable 'submitted', 'Submitted'
+          th= sortable 'released', 'Released'
+          th= sortable 'created_at', 'Created'
+          th= sortable 'updated_at', 'Updated'
+          th colspan=3 = t 'actions'
 
-  tbody
-    - for submission in @submissions
-      tr  class=cycle(:odd, :even)  
-        td= submission.user.nil?? '???' : submission.user.name
-        td= submission.population_submissions[0].nil?? '' : submission.population_submissions[0].site_name
-        td= submission.country
-        td= submission.phenotype
-        td= submission.data_type == 'Population estimate' ? 'X' : ''
-        td= submission.data_type == 'Range polygon' ? 'X' : ''
-        td= submission.right_to_grant_permission ? 'Y' : 'N'
-        td= submission.population_submissions[0].nil?? '' : (submission.population_submissions[0].submitted ? 'Y' : 'N')
-        td= submission.population_submissions[0].nil?? '' : (submission.population_submissions[0].released ? 'Y' : 'N')
-        td= submission.created_at
-        td= submission.updated_at
-        td.action= link_to t('show'), submission
-        td.action= link_to t('edit'), edit_submission_path(submission)
-        td.action= link_to t('destroy'), submission, :confirm => t('are_you_sure'), :method => :delete
+      tbody
+        - for submission in @submissions
+          tr  class=cycle(:odd, :even)  
+            td= submission.user.nil?? '???' : submission.user.name
+            td= submission.population_submissions[0].nil?? '' : submission.population_submissions[0].site_name
+            td= submission.country
+            td= submission.phenotype
+            td= submission.data_type == 'Population estimate' ? 'X' : ''
+            td= submission.data_type == 'Range polygon' ? 'X' : ''
+            td= submission.right_to_grant_permission ? 'Y' : 'N'
+            td= submission.population_submissions[0].nil?? '' : (submission.population_submissions[0].submitted ? 'Y' : 'N')
+            td= submission.population_submissions[0].nil?? '' : (submission.population_submissions[0].released ? 'Y' : 'N')
+            td= submission.created_at
+            td= submission.updated_at
+            td.action= link_to t('show'), submission
+            td.action= link_to t('edit'), edit_submission_path(submission)
+            td.action= link_to t('destroy'), submission, :confirm => t('are_you_sure'), :method => :delete

--- a/app/views/submissions/new.html.slim
+++ b/app/views/submissions/new.html.slim
@@ -1,5 +1,2 @@
-.container
-  .row
-    .col-xs-12
-      h1= t '.title'
-      = render 'form'
+- @title = t '.title'
+= render 'form'

--- a/app/views/submissions/show.html.slim
+++ b/app/views/submissions/show.html.slim
@@ -1,3 +1,5 @@
-h1= Submission
-.restated_survey_info
-  = render :partial => "submission_info", :locals => { :s => @submission }
+.row
+  .col-xs-12
+    h1= Submission
+    .restated_survey_info
+      = render :partial => "submission_info", :locals => { :s => @submission }

--- a/app/views/superuser/index.html.slim
+++ b/app/views/superuser/index.html.slim
@@ -1,18 +1,20 @@
-- if current_user.admin?
-  h1 Administrative resources
-  h3
-    = link_to 'Recent Submissions', '/submissions'
-  h3
-    = link_to 'Data Request Forms', '/data_request_forms'
-  h3
-    = link_to 'Users', '/users'
-  h3
-    = link_to 'All Narratives and Footnotes', '/report_narratives'
-  h3
-    = link_to 'Replacement manager', '/changes'
-  h3
-    = link_to '2013 Africa reports', '/preview_report/2013_africa_final/Loxodonta_africana/2013/Africa'
-  h3
-    = link_to 'Recalculate change interpreters (takes up to 1 minute after clicking)', '/recalc'
-- else
-  | This account is not authorized to access this page.
+.row
+  .col-xs-12
+    - if current_user.admin?
+      h1 Administrative resources
+      h3
+        = link_to 'Recent Submissions', '/submissions'
+      h3
+        = link_to 'Data Request Forms', '/data_request_forms'
+      h3
+        = link_to 'Users', '/users'
+      h3
+        = link_to 'All Narratives and Footnotes', '/report_narratives'
+      h3
+        = link_to 'Replacement manager', '/changes'
+      h3
+        = link_to '2013 Africa reports', '/preview_report/2013_africa_final/Loxodonta_africana/2013/Africa'
+      h3
+        = link_to 'Recalculate change interpreters (takes up to 1 minute after clicking)', '/recalc'
+    - else
+      | This account is not authorized to access this page.

--- a/app/views/survey_aerial_sample_count_strata/_form.html.slim
+++ b/app/views/survey_aerial_sample_count_strata/_form.html.slim
@@ -27,6 +27,4 @@
     -if current_user.admin?
       = f.input :is_mike_site, :as => :radio
       = f.input :mike_site
-  = f.buttons do
-    = f.commit_button :label => 'Save and enter another stratum'
-    = f.commit_button :label => 'This is my final stratum'
+  = render 'strata_actions', f: f

--- a/app/views/survey_aerial_sample_count_strata/edit.html.slim
+++ b/app/views/survey_aerial_sample_count_strata/edit.html.slim
@@ -1,2 +1,0 @@
-h1= t '.title'
-= render 'form'

--- a/app/views/survey_aerial_sample_count_strata/new.html.slim
+++ b/app/views/survey_aerial_sample_count_strata/new.html.slim
@@ -1,2 +1,0 @@
-h1= t '.title'
-= render 'form'

--- a/app/views/survey_aerial_sample_count_strata/show.html.slim
+++ b/app/views/survey_aerial_sample_count_strata/show.html.slim
@@ -1,64 +1,66 @@
-h1= t '.title'
-.restated_survey_info
-  = render :partial => "submission_info", :locals => { :s => @submission }
-h4
-  - if @level.stratum_name == ''
-    .count_stratum_name Stratum ## @level.id 
-  - else
-    .count_stratum_name= @level.stratum_name
-.show_stratum
-  == best_label_for 'stratum_area'
-  = @level.stratum_area
-.show_stratum
-  == best_label_for 'population_estimate'
-  = @level.population_estimate
-.show_stratum
-  == best_label_for 'population_variance'
-  = @level.population_variance
-.show_stratum
-  == best_label_for 'population_standard_error'
-  = @level.population_standard_error
-.show_stratum
-  == best_label_for 'population_t'
-  = @level.population_t
-.show_stratum
-  == best_label_for 'population_degrees_of_freedom'
-  = @level.population_degrees_of_freedom
-.show_stratum
-  == best_label_for 'population_confidence_interval'
-  = @level.population_confidence_interval
-.show_stratum
-  == best_label_for 'population_lower_confidence_limit'
-  = @level.population_lower_confidence_limit
-.show_stratum
-  == best_label_for 'population_upper_confidence_limit'
-  = @level.population_upper_confidence_limit
-.show_stratum
-  == best_label_for 'population_no_precision_estimate_available'
-  = @level.population_no_precision_estimate_available
-.show_stratum
-  == best_label_for 'sampling_intensity'
-  = @level.sampling_intensity
-.show_stratum
-  == best_label_for 'transects_covered'
-  = @level.transects_covered
-.show_stratum
-  == best_label_for 'transects_covered_total_length'
-  = @level.transects_covered_total_length
-.show_stratum
-  == best_label_for 'seen_in_transects'
-  = @level.seen_in_transects
-.show_stratum
-  == best_label_for 'seen_outside_transects'
-  = @level.seen_outside_transects
-.show_stratum
-  == best_label_for 'carcasses_fresh'
-  = @level.carcasses_fresh
-.show_stratum
-  == best_label_for 'carcasses_old'
-  = @level.carcasses_old
-.show_stratum
-  == best_label_for 'carcasses_very_old'
-  = @level.carcasses_very_old
-== map_stratum @level
+.row
+  .col-xs-12
+    h1= t '.title'
+    .restated_survey_info
+      = render :partial => "submission_info", :locals => { :s => @submission }
+    h4
+      - if @level.stratum_name.blank?
+        .count_stratum_name = "Stratum ##{@level.id}"
+      - else
+        .count_stratum_name= @level.stratum_name
+    .show_stratum
+      == best_label_for 'stratum_area'
+      = @level.stratum_area
+    .show_stratum
+      == best_label_for 'population_estimate'
+      = @level.population_estimate
+    .show_stratum
+      == best_label_for 'population_variance'
+      = @level.population_variance
+    .show_stratum
+      == best_label_for 'population_standard_error'
+      = @level.population_standard_error
+    .show_stratum
+      == best_label_for 'population_t'
+      = @level.population_t
+    .show_stratum
+      == best_label_for 'population_degrees_of_freedom'
+      = @level.population_degrees_of_freedom
+    .show_stratum
+      == best_label_for 'population_confidence_interval'
+      = @level.population_confidence_interval
+    .show_stratum
+      == best_label_for 'population_lower_confidence_limit'
+      = @level.population_lower_confidence_limit
+    .show_stratum
+      == best_label_for 'population_upper_confidence_limit'
+      = @level.population_upper_confidence_limit
+    .show_stratum
+      == best_label_for 'population_no_precision_estimate_available'
+      = @level.population_no_precision_estimate_available
+    .show_stratum
+      == best_label_for 'sampling_intensity'
+      = @level.sampling_intensity
+    .show_stratum
+      == best_label_for 'transects_covered'
+      = @level.transects_covered
+    .show_stratum
+      == best_label_for 'transects_covered_total_length'
+      = @level.transects_covered_total_length
+    .show_stratum
+      == best_label_for 'seen_in_transects'
+      = @level.seen_in_transects
+    .show_stratum
+      == best_label_for 'seen_outside_transects'
+      = @level.seen_outside_transects
+    .show_stratum
+      == best_label_for 'carcasses_fresh'
+      = @level.carcasses_fresh
+    .show_stratum
+      == best_label_for 'carcasses_old'
+      = @level.carcasses_old
+    .show_stratum
+      == best_label_for 'carcasses_very_old'
+      = @level.carcasses_very_old
+    == map_stratum @level
 

--- a/app/views/survey_aerial_sample_counts/_form.html.slim
+++ b/app/views/survey_aerial_sample_counts/_form.html.slim
@@ -7,4 +7,4 @@
     = f.input :total_possible_transects
     = f.input :surveyed_at_stratum_level, :as => :radio
     = f.input :stratum_level_data_submitted, :as => :radio
-  = f.buttons
+  = f.actions

--- a/app/views/survey_aerial_sample_counts/edit.html.slim
+++ b/app/views/survey_aerial_sample_counts/edit.html.slim
@@ -1,2 +1,0 @@
-h1= t '.title'
-= render 'form'

--- a/app/views/survey_aerial_sample_counts/new.html.slim
+++ b/app/views/survey_aerial_sample_counts/new.html.slim
@@ -1,2 +1,0 @@
-h1= t '.title'
-= render 'form'

--- a/app/views/survey_aerial_sample_counts/show.html.slim
+++ b/app/views/survey_aerial_sample_counts/show.html.slim
@@ -1,4 +1,0 @@
-h1= t '.title'
-.restated_survey_info
-  = render :partial => "submission_info", :locals => { :s => @submission }
-== map_aggregate @level

--- a/app/views/survey_aerial_total_count_strata/_form.html.slim
+++ b/app/views/survey_aerial_total_count_strata/_form.html.slim
@@ -20,6 +20,4 @@
     -if current_user.admin?
       = f.input :is_mike_site, :as => :radio
       = f.input :mike_site
-  = f.buttons do
-    = f.commit_button :label => 'Save and enter another stratum'
-    = f.commit_button :label => 'This is my final stratum'
+  = render 'strata_actions', f: f

--- a/app/views/survey_aerial_total_count_strata/edit.html.slim
+++ b/app/views/survey_aerial_total_count_strata/edit.html.slim
@@ -1,5 +1,0 @@
-h1= t '.title'
-p
-  = link_to t('back'), survey_aerial_total_count_strata_path
-  = link_to t('show'), @survey_aerial_total_count_stratum
-= render 'form'

--- a/app/views/survey_aerial_total_count_strata/new.html.slim
+++ b/app/views/survey_aerial_total_count_strata/new.html.slim
@@ -1,2 +1,0 @@
-h1= t '.title'
-= render 'form'

--- a/app/views/survey_aerial_total_count_strata/show.html.slim
+++ b/app/views/survey_aerial_total_count_strata/show.html.slim
@@ -1,43 +1,45 @@
-h1= t '.title'
-.restated_survey_info
-  = render :partial => "submission_info", :locals => { :s => @submission }
-h4
-  - if @level.stratum_name == ''
-    .count_stratum_name Stratum ## @level.id 
-  - else
-    .count_stratum_name= @level.stratum_name
-.show_stratum
-  == best_label_for 'stratum_area'
-  = @level.stratum_area
-.show_stratum
-  == best_label_for 'population_estimate'
-  = @level.population_estimate
-.show_stratum
-  == best_label_for 'average_speed'
-  = @level.average_speed
-.show_stratum
-  == best_label_for 'average_transect_spacing'
-  = @level.average_transect_spacing
-.show_stratum
-  == best_label_for 'average_searching_rate'
-  = @level.average_searching_rate
-.show_stratum
-  == best_label_for 'transects_covered'
-  = @level.transects_covered
-.show_stratum
-  == best_label_for 'transects_covered_total_length'
-  = @level.transects_covered_total_length
-.show_stratum
-  == best_label_for 'observations'
-  = @level.observations
-.show_stratum
-  == best_label_for 'carcasses_fresh'
-  = @level.carcasses_fresh
-.show_stratum
-  == best_label_for 'carcasses_old'
-  = @level.carcasses_old
-.show_stratum
-  == best_label_for 'carcasses_very_old'
-  = @level.carcasses_very_old
-== map_stratum @level
+.row
+  .col-xs-12
+    h1= t '.title'
+    .restated_survey_info
+      = render :partial => "submission_info", :locals => { :s => @submission }
+    h4
+      - if @level.stratum_name.blank?
+        .count_stratum_name = "Stratum ##{@level.id}"
+      - else
+        .count_stratum_name= @level.stratum_name
+    .show_stratum
+      == best_label_for 'stratum_area'
+      = @level.stratum_area
+    .show_stratum
+      == best_label_for 'population_estimate'
+      = @level.population_estimate
+    .show_stratum
+      == best_label_for 'average_speed'
+      = @level.average_speed
+    .show_stratum
+      == best_label_for 'average_transect_spacing'
+      = @level.average_transect_spacing
+    .show_stratum
+      == best_label_for 'average_searching_rate'
+      = @level.average_searching_rate
+    .show_stratum
+      == best_label_for 'transects_covered'
+      = @level.transects_covered
+    .show_stratum
+      == best_label_for 'transects_covered_total_length'
+      = @level.transects_covered_total_length
+    .show_stratum
+      == best_label_for 'observations'
+      = @level.observations
+    .show_stratum
+      == best_label_for 'carcasses_fresh'
+      = @level.carcasses_fresh
+    .show_stratum
+      == best_label_for 'carcasses_old'
+      = @level.carcasses_old
+    .show_stratum
+      == best_label_for 'carcasses_very_old'
+      = @level.carcasses_very_old
+    == map_stratum @level
 

--- a/app/views/survey_aerial_total_counts/_form.html.slim
+++ b/app/views/survey_aerial_total_counts/_form.html.slim
@@ -6,4 +6,4 @@
     = f.input :population_submission_id, :as => :hidden, :value => @population_submission.id
     = f.input :surveyed_at_stratum_level, :as => :radio
     = f.input :stratum_level_data_submitted, :as => :radio
-  = f.buttons
+  = f.actions

--- a/app/views/survey_aerial_total_counts/edit.html.slim
+++ b/app/views/survey_aerial_total_counts/edit.html.slim
@@ -1,2 +1,0 @@
-h1= t '.title'
-= render 'form'

--- a/app/views/survey_aerial_total_counts/new.html.slim
+++ b/app/views/survey_aerial_total_counts/new.html.slim
@@ -1,2 +1,0 @@
-h1= t '.title'
-= render 'form'

--- a/app/views/survey_aerial_total_counts/show.html.slim
+++ b/app/views/survey_aerial_total_counts/show.html.slim
@@ -1,4 +1,0 @@
-h1= t '.title'
-.restated_survey_info
-  = render :partial => "submission_info", :locals => { :s => @submission }
-== map_aggregate @level

--- a/app/views/survey_dung_count_line_transect_strata/_form.html.slim
+++ b/app/views/survey_dung_count_line_transect_strata/_form.html.slim
@@ -65,6 +65,4 @@
     -if current_user.admin?
       = f.input :is_mike_site, :as => :radio
       = f.input :mike_site
-  = f.buttons do
-    = f.commit_button :label => 'Save and enter another stratum'
-    = f.commit_button :label => 'This is my final stratum'
+  = render 'strata_actions', f: f

--- a/app/views/survey_dung_count_line_transect_strata/edit.html.slim
+++ b/app/views/survey_dung_count_line_transect_strata/edit.html.slim
@@ -1,5 +1,0 @@
-h1= t '.title'
-p
-  = link_to t('back'), survey_dung_count_line_transect_strata_path
-  = link_to t('show'), @survey_dung_count_line_transect_stratum
-= render 'form'

--- a/app/views/survey_dung_count_line_transect_strata/new.html.slim
+++ b/app/views/survey_dung_count_line_transect_strata/new.html.slim
@@ -1,2 +1,0 @@
-h1= t '.title'
-= render 'form'

--- a/app/views/survey_dung_count_line_transect_strata/show.html.slim
+++ b/app/views/survey_dung_count_line_transect_strata/show.html.slim
@@ -1,178 +1,180 @@
-h1= t '.title'
-.restated_survey_info
-  = render :partial => "submission_info", :locals => { :s => @submission }
-.show
-  h4
-    - if @level.stratum_name == ''
-      .count_stratum_name Stratum ## @level.id 
-    - else
-      .count_stratum_name= @level.stratum_name
-  .show_stratum
-    == best_label_for 'stratum_area'
-    = @level.stratum_area
-  .show_stratum
-    == best_label_for 'population_estimate'
-    = @level.population_estimate
-  .show_stratum
-    == best_label_for 'population_variance'
-    = @level.population_variance
-  .show_stratum
-    == best_label_for 'population_standard_error'
-    = @level.population_standard_error
-  .show_stratum
-    == best_label_for 'population_t'
-    = @level.population_t
-  .show_stratum
-    == best_label_for 'population_degrees_of_freedom'
-    = @level.population_degrees_of_freedom
-  .show_stratum
-    == best_label_for 'population_confidence_interval'
-    = @level.population_confidence_interval
-  .show_stratum
-    == best_label_for 'population_lower_confidence_limit'
-    = @level.population_lower_confidence_limit
-  .show_stratum
-    == best_label_for 'population_upper_confidence_limit'
-    = @level.population_upper_confidence_limit
-  .show_stratum
-    == best_label_for 'population_no_precision_estimate_available'
-    = @level.population_no_precision_estimate_available
-  .show_stratum
-    == best_label_for 'population_asymmetric_lower_confidence_interval'
-    = @level.population_asymmetric_lower_confidence_interval
-  .show_stratum
-    == best_label_for 'population_asymmetric_upper_confidence_interval'
-    = @level.population_asymmetric_upper_confidence_interval
-  .show_stratum
-    == best_label_for 'transects_covered'
-    = @level.transects_covered
-  .show_stratum
-    == best_label_for 'transects_covered_total_length'
-    = @level.transects_covered_total_length
-  .show_stratum
-    == best_label_for 'strip_width'
-    = @level.strip_width
-  .show_stratum
-    == best_label_for 'observations'
-    = @level.observations
-  .show_stratum
-    == best_label_for 'observations_distance_method'
-    = @level.observations_distance_method
-  .show_stratum
-    == best_label_for 'actually_seen'
-    = @level.actually_seen
-  .show_stratum
-    == best_label_for 'dung_piles'
-    = @level.dung_piles
-  .show_stratum
-    == best_label_for 'dung_decay_rate_measurement_method'
-    = @level.dung_decay_rate_measurement_method
-  .show_stratum
-    == best_label_for 'dung_decay_rate_estimate_used'
-    = @level.dung_decay_rate_estimate_used
-  .show_stratum
-    == best_label_for 'dung_decay_rate_measurement_site'
-    = @level.dung_decay_rate_measurement_site
-  .show_stratum
-    == best_label_for 'dung_decay_rate_measurement_year'
-    = @level.dung_decay_rate_measurement_year
-  .show_stratum
-    == best_label_for 'dung_decay_rate_reference'
-    = @level.dung_decay_rate_reference
-  .show_stratum
-    == best_label_for 'dung_decay_rate_variance'
-    = @level.dung_decay_rate_variance
-  .show_stratum
-    == best_label_for 'dung_decay_rate_standard_error'
-    = @level.dung_decay_rate_standard_error
-  .show_stratum
-    == best_label_for 'dung_decay_rate_t'
-    = @level.dung_decay_rate_t
-  .show_stratum
-    == best_label_for 'dung_decay_rate_degrees_of_freedom'
-    = @level.dung_decay_rate_degrees_of_freedom
-  .show_stratum
-    == best_label_for 'dung_decay_rate_confidence_interval'
-    = @level.dung_decay_rate_confidence_interval
-  .show_stratum
-    == best_label_for 'dung_decay_rate_lower_confidence_limit'
-    = @level.dung_decay_rate_lower_confidence_limit
-  .show_stratum
-    == best_label_for 'dung_decay_rate_upper_confidence_limit'
-    = @level.dung_decay_rate_upper_confidence_limit
-  .show_stratum
-    == best_label_for 'dung_decay_rate_no_precision_estimate_available'
-    = @level.dung_decay_rate_no_precision_estimate_available
-  .show_stratum
-    == best_label_for 'defecation_rate_measured_on_site'
-    = @level.defecation_rate_measured_on_site
-  .show_stratum
-    == best_label_for 'defecation_rate_estimate_used'
-    = @level.defecation_rate_estimate_used
-  .show_stratum
-    == best_label_for 'defecation_rate_measurement_site'
-    = @level.defecation_rate_measurement_site
-  .show_stratum
-    == best_label_for 'defecation_rate_reference'
-    = @level.defecation_rate_reference
-  .show_stratum
-    == best_label_for 'defecation_rate_variance'
-    = @level.defecation_rate_variance
-  .show_stratum
-    == best_label_for 'defecation_rate_standard_error'
-    = @level.defecation_rate_standard_error
-  .show_stratum
-    == best_label_for 'defecation_rate_t'
-    = @level.defecation_rate_t
-  .show_stratum
-    == best_label_for 'defecation_rate_degrees_of_freedom'
-    = @level.defecation_rate_degrees_of_freedom
-  .show_stratum
-    == best_label_for 'defecation_rate_confidence_interval'
-    = @level.defecation_rate_confidence_interval
-  .show_stratum
-    == best_label_for 'defecation_rate_lower_confidence_limit'
-    = @level.defecation_rate_lower_confidence_limit
-  .show_stratum
-    == best_label_for 'defecation_rate_upper_confidence_limit'
-    = @level.defecation_rate_upper_confidence_limit
-  .show_stratum
-    == best_label_for 'defecation_rate_no_precision_estimate_available'
-    = @level.defecation_rate_no_precision_estimate_available
-  .show_stratum
-    == best_label_for 'dung_density_estimate'
-    = @level.dung_density_estimate
-  .show_stratum
-    == best_label_for 'dung_density_variance'
-    = @level.dung_density_variance
-  .show_stratum
-    == best_label_for 'dung_density_standard_error'
-    = @level.dung_density_standard_error
-  .show_stratum
-    == best_label_for 'dung_density_t'
-    = @level.dung_density_t
-  .show_stratum
-    == best_label_for 'dung_density_degrees_of_freedom'
-    = @level.dung_density_degrees_of_freedom
-  .show_stratum
-    == best_label_for 'dung_density_confidence_interval'
-    = @level.dung_density_confidence_interval
-  .show_stratum
-    == best_label_for 'dung_density_lower_confidence_limit'
-    = @level.dung_density_lower_confidence_limit
-  .show_stratum
-    == best_label_for 'dung_density_upper_confidence_limit'
-    = @level.dung_density_upper_confidence_limit
-  .show_stratum
-    == best_label_for 'dung_density_asymmetric_upper_confidence_interval'
-    = @level.dung_density_asymmetric_upper_confidence_interval
-  .show_stratum
-    == best_label_for 'dung_density_asymmetric_lower_confidence_interval'
-    = @level.dung_density_asymmetric_lower_confidence_interval
-  .show_stratum
-    == best_label_for 'dung_density_no_precision_estimate_available'
-    = @level.dung_density_no_precision_estimate_available
-  .show_stratum
-    == best_label_for 'dung_encounter_rate'
-    = @level.dung_encounter_rate
-  == map_stratum @level
+.row
+  .col-xs-12
+    h1= t '.title'
+    .restated_survey_info
+      = render :partial => "submission_info", :locals => { :s => @submission }
+    .show
+      h4
+        - if @level.stratum_name.blank?
+          .count_stratum_name Stratum ##{@level.id}
+        - else
+          .count_stratum_name= @level.stratum_name
+      .show_stratum
+        == best_label_for 'stratum_area'
+        = @level.stratum_area
+      .show_stratum
+        == best_label_for 'population_estimate'
+        = @level.population_estimate
+      .show_stratum
+        == best_label_for 'population_variance'
+        = @level.population_variance
+      .show_stratum
+        == best_label_for 'population_standard_error'
+        = @level.population_standard_error
+      .show_stratum
+        == best_label_for 'population_t'
+        = @level.population_t
+      .show_stratum
+        == best_label_for 'population_degrees_of_freedom'
+        = @level.population_degrees_of_freedom
+      .show_stratum
+        == best_label_for 'population_confidence_interval'
+        = @level.population_confidence_interval
+      .show_stratum
+        == best_label_for 'population_lower_confidence_limit'
+        = @level.population_lower_confidence_limit
+      .show_stratum
+        == best_label_for 'population_upper_confidence_limit'
+        = @level.population_upper_confidence_limit
+      .show_stratum
+        == best_label_for 'population_no_precision_estimate_available'
+        = @level.population_no_precision_estimate_available
+      .show_stratum
+        == best_label_for 'population_asymmetric_lower_confidence_interval'
+        = @level.population_asymmetric_lower_confidence_interval
+      .show_stratum
+        == best_label_for 'population_asymmetric_upper_confidence_interval'
+        = @level.population_asymmetric_upper_confidence_interval
+      .show_stratum
+        == best_label_for 'transects_covered'
+        = @level.transects_covered
+      .show_stratum
+        == best_label_for 'transects_covered_total_length'
+        = @level.transects_covered_total_length
+      .show_stratum
+        == best_label_for 'strip_width'
+        = @level.strip_width
+      .show_stratum
+        == best_label_for 'observations'
+        = @level.observations
+      .show_stratum
+        == best_label_for 'observations_distance_method'
+        = @level.observations_distance_method
+      .show_stratum
+        == best_label_for 'actually_seen'
+        = @level.actually_seen
+      .show_stratum
+        == best_label_for 'dung_piles'
+        = @level.dung_piles
+      .show_stratum
+        == best_label_for 'dung_decay_rate_measurement_method'
+        = @level.dung_decay_rate_measurement_method
+      .show_stratum
+        == best_label_for 'dung_decay_rate_estimate_used'
+        = @level.dung_decay_rate_estimate_used
+      .show_stratum
+        == best_label_for 'dung_decay_rate_measurement_site'
+        = @level.dung_decay_rate_measurement_site
+      .show_stratum
+        == best_label_for 'dung_decay_rate_measurement_year'
+        = @level.dung_decay_rate_measurement_year
+      .show_stratum
+        == best_label_for 'dung_decay_rate_reference'
+        = @level.dung_decay_rate_reference
+      .show_stratum
+        == best_label_for 'dung_decay_rate_variance'
+        = @level.dung_decay_rate_variance
+      .show_stratum
+        == best_label_for 'dung_decay_rate_standard_error'
+        = @level.dung_decay_rate_standard_error
+      .show_stratum
+        == best_label_for 'dung_decay_rate_t'
+        = @level.dung_decay_rate_t
+      .show_stratum
+        == best_label_for 'dung_decay_rate_degrees_of_freedom'
+        = @level.dung_decay_rate_degrees_of_freedom
+      .show_stratum
+        == best_label_for 'dung_decay_rate_confidence_interval'
+        = @level.dung_decay_rate_confidence_interval
+      .show_stratum
+        == best_label_for 'dung_decay_rate_lower_confidence_limit'
+        = @level.dung_decay_rate_lower_confidence_limit
+      .show_stratum
+        == best_label_for 'dung_decay_rate_upper_confidence_limit'
+        = @level.dung_decay_rate_upper_confidence_limit
+      .show_stratum
+        == best_label_for 'dung_decay_rate_no_precision_estimate_available'
+        = @level.dung_decay_rate_no_precision_estimate_available
+      .show_stratum
+        == best_label_for 'defecation_rate_measured_on_site'
+        = @level.defecation_rate_measured_on_site
+      .show_stratum
+        == best_label_for 'defecation_rate_estimate_used'
+        = @level.defecation_rate_estimate_used
+      .show_stratum
+        == best_label_for 'defecation_rate_measurement_site'
+        = @level.defecation_rate_measurement_site
+      .show_stratum
+        == best_label_for 'defecation_rate_reference'
+        = @level.defecation_rate_reference
+      .show_stratum
+        == best_label_for 'defecation_rate_variance'
+        = @level.defecation_rate_variance
+      .show_stratum
+        == best_label_for 'defecation_rate_standard_error'
+        = @level.defecation_rate_standard_error
+      .show_stratum
+        == best_label_for 'defecation_rate_t'
+        = @level.defecation_rate_t
+      .show_stratum
+        == best_label_for 'defecation_rate_degrees_of_freedom'
+        = @level.defecation_rate_degrees_of_freedom
+      .show_stratum
+        == best_label_for 'defecation_rate_confidence_interval'
+        = @level.defecation_rate_confidence_interval
+      .show_stratum
+        == best_label_for 'defecation_rate_lower_confidence_limit'
+        = @level.defecation_rate_lower_confidence_limit
+      .show_stratum
+        == best_label_for 'defecation_rate_upper_confidence_limit'
+        = @level.defecation_rate_upper_confidence_limit
+      .show_stratum
+        == best_label_for 'defecation_rate_no_precision_estimate_available'
+        = @level.defecation_rate_no_precision_estimate_available
+      .show_stratum
+        == best_label_for 'dung_density_estimate'
+        = @level.dung_density_estimate
+      .show_stratum
+        == best_label_for 'dung_density_variance'
+        = @level.dung_density_variance
+      .show_stratum
+        == best_label_for 'dung_density_standard_error'
+        = @level.dung_density_standard_error
+      .show_stratum
+        == best_label_for 'dung_density_t'
+        = @level.dung_density_t
+      .show_stratum
+        == best_label_for 'dung_density_degrees_of_freedom'
+        = @level.dung_density_degrees_of_freedom
+      .show_stratum
+        == best_label_for 'dung_density_confidence_interval'
+        = @level.dung_density_confidence_interval
+      .show_stratum
+        == best_label_for 'dung_density_lower_confidence_limit'
+        = @level.dung_density_lower_confidence_limit
+      .show_stratum
+        == best_label_for 'dung_density_upper_confidence_limit'
+        = @level.dung_density_upper_confidence_limit
+      .show_stratum
+        == best_label_for 'dung_density_asymmetric_upper_confidence_interval'
+        = @level.dung_density_asymmetric_upper_confidence_interval
+      .show_stratum
+        == best_label_for 'dung_density_asymmetric_lower_confidence_interval'
+        = @level.dung_density_asymmetric_lower_confidence_interval
+      .show_stratum
+        == best_label_for 'dung_density_no_precision_estimate_available'
+        = @level.dung_density_no_precision_estimate_available
+      .show_stratum
+        == best_label_for 'dung_encounter_rate'
+        = @level.dung_encounter_rate
+      == map_stratum @level

--- a/app/views/survey_dung_count_line_transects/_form.html.slim
+++ b/app/views/survey_dung_count_line_transects/_form.html.slim
@@ -1,9 +1,0 @@
-.restated_survey_info
-  = render :partial => "submission_info", :locals => { :s => @submission }
-= semantic_form_for @survey_dung_count_line_transect do |f|
-  = render "shared/error_messages", :target => @survey_dung_count_line_transect
-  = f.inputs do
-    = f.input :population_submission_id, :as => :hidden, :value => @population_submission.id
-    = f.input :surveyed_at_stratum_level, :as => :radio
-    = f.input :stratum_level_data_submitted, :as => :radio
-  = f.buttons

--- a/app/views/survey_dung_count_line_transects/edit.html.slim
+++ b/app/views/survey_dung_count_line_transects/edit.html.slim
@@ -1,5 +1,0 @@
-h1= t '.title'
-p
-  = link_to t('back'), survey_dung_count_line_transects_path
-  = link_to t('show'), @survey_dung_count_line_transect
-= render 'form'

--- a/app/views/survey_dung_count_line_transects/index.html.slim
+++ b/app/views/survey_dung_count_line_transects/index.html.slim
@@ -1,20 +1,22 @@
-h1= t('.title')
-p= link_to t('.new'), new_survey_dung_count_line_transect_path
+.row
+  .col-xs-12
+    h1= t('.title')
+    p= link_to t('.new'), new_survey_dung_count_line_transect_path
 
-table
-  thead
-    tr
-      th= SurveyDungCountLineTransect.human_attribute_name :population_submission_id
-      th= SurveyDungCountLineTransect.human_attribute_name :surveyed_at_stratum_level
-      th= SurveyDungCountLineTransect.human_attribute_name :stratum_level_data_submitted
-      th colspan=3 = t 'actions'
-  
-  tbody
-    - for survey_dung_count_line_transect in @survey_dung_count_line_transects
-      tr  class=cycle(:odd, :even)  
-        td= survey_dung_count_line_transect.population_submission_id
-        td= survey_dung_count_line_transect.surveyed_at_stratum_level
-        td= survey_dung_count_line_transect.stratum_level_data_submitted
-        td.action= link_to t('show'), survey_dung_count_line_transect
-        td.action= link_to t('edit'), edit_survey_dung_count_line_transect_path(survey_dung_count_line_transect)
-        td.action= link_to t('destroy'), survey_dung_count_line_transect, :confirm => t('are_you_sure'), :method => :delete
+    table.table
+      thead
+        tr
+          th= SurveyDungCountLineTransect.human_attribute_name :population_submission_id
+          th= SurveyDungCountLineTransect.human_attribute_name :surveyed_at_stratum_level
+          th= SurveyDungCountLineTransect.human_attribute_name :stratum_level_data_submitted
+          th colspan=3 = t 'actions'
+      
+      tbody
+        - for survey_dung_count_line_transect in @survey_dung_count_line_transects
+          tr  class=cycle(:odd, :even)  
+            td= survey_dung_count_line_transect.population_submission_id
+            td= survey_dung_count_line_transect.surveyed_at_stratum_level
+            td= survey_dung_count_line_transect.stratum_level_data_submitted
+            td.action= link_to t('show'), survey_dung_count_line_transect
+            td.action= link_to t('edit'), edit_survey_dung_count_line_transect_path(survey_dung_count_line_transect)
+            td.action= link_to t('destroy'), survey_dung_count_line_transect, :confirm => t('are_you_sure'), :method => :delete

--- a/app/views/survey_dung_count_line_transects/new.html.slim
+++ b/app/views/survey_dung_count_line_transects/new.html.slim
@@ -1,2 +1,0 @@
-h1= t '.title'
-= render 'form'

--- a/app/views/survey_dung_count_line_transects/show.html.slim
+++ b/app/views/survey_dung_count_line_transects/show.html.slim
@@ -1,4 +1,0 @@
-h1= t '.title'
-.restated_survey_info
-  = render :partial => "submission_info", :locals => { :s => @submission }
-== map_aggregate @level

--- a/app/views/survey_faecal_dna_strata/_form.html.slim
+++ b/app/views/survey_faecal_dna_strata/_form.html.slim
@@ -23,6 +23,4 @@
     -if current_user.admin?
       = f.input :is_mike_site, :as => :radio
       = f.input :mike_site
-  = f.buttons do
-    = f.commit_button :label => 'Save and enter another stratum'
-    = f.commit_button :label => 'This is my final stratum'
+  = render 'strata_actions', f: f

--- a/app/views/survey_faecal_dna_strata/edit.html.slim
+++ b/app/views/survey_faecal_dna_strata/edit.html.slim
@@ -1,5 +1,0 @@
-h1= t '.title'
-p
-  = link_to t('back'), survey_faecal_dna_strata_path
-  = link_to t('show'), @survey_faecal_dna_stratum
-= render 'form'

--- a/app/views/survey_faecal_dna_strata/new.html.slim
+++ b/app/views/survey_faecal_dna_strata/new.html.slim
@@ -1,2 +1,0 @@
-h1= t '.title'
-= render 'form'

--- a/app/views/survey_faecal_dna_strata/show.html.slim
+++ b/app/views/survey_faecal_dna_strata/show.html.slim
@@ -1,56 +1,58 @@
-h1= t '.title'
-.restated_survey_info
-  = render :partial => "submission_info", :locals => { :s => @submission }
-.show
-  h4
-    - if @level.stratum_name == ''
-      .count_stratum_name Stratum ## @level.id 
-    - else
-      .count_stratum_name= @level.stratum_name
-  .show_stratum
-    == best_label_for 'stratum_area'
-    = @level.stratum_area
-  .show_stratum
-    == best_label_for 'population_estimate'
-    = @level.population_estimate
-  .show_stratum
-    == best_label_for 'population_variance'
-    = @level.population_variance
-  .show_stratum
-    == best_label_for 'population_standard_error'
-    = @level.population_standard_error
-  .show_stratum
-    == best_label_for 'population_t'
-    = @level.population_t
-  .show_stratum
-    == best_label_for 'population_degrees_of_freedom'
-    = @level.population_degrees_of_freedom
-  .show_stratum
-    == best_label_for 'population_confidence_interval'
-    = @level.population_confidence_interval
-  .show_stratum
-    == best_label_for 'population_lower_confidence_limit'
-    = @level.population_lower_confidence_limit
-  .show_stratum
-    == best_label_for 'population_upper_confidence_limit'
-    = @level.population_upper_confidence_limit
-  .show_stratum
-    == best_label_for 'population_no_precision_estimate_available'
-    = @level.population_no_precision_estimate_available
-  .show_stratum
-    == best_label_for 'method_of_analysis'
-    = @level.method_of_analysis
-  .show_stratum
-    == best_label_for 'area_calculation_method'
-    = @level.area_calculation_method
-  .show_stratum
-    == best_label_for 'genotypes_identified'
-    = @level.genotypes_identified
-  .show_stratum
-    == best_label_for 'samples_analyzed'
-    = @level.samples_analyzed
-  .show_stratum
-    == best_label_for 'sampling_locations'
-    = @level.sampling_locations
-  == map_stratum @level
+.row
+  .col-xs-12
+    h1= t '.title'
+    .restated_survey_info
+      = render :partial => "submission_info", :locals => { :s => @submission }
+    .show
+      h4
+        - if @level.stratum_name.blank?
+          .count_stratum_name = "Stratum ##{@level.id}"
+        - else
+          .count_stratum_name = @level.stratum_name
+      .show_stratum
+        == best_label_for 'stratum_area'
+        = @level.stratum_area
+      .show_stratum
+        == best_label_for 'population_estimate'
+        = @level.population_estimate
+      .show_stratum
+        == best_label_for 'population_variance'
+        = @level.population_variance
+      .show_stratum
+        == best_label_for 'population_standard_error'
+        = @level.population_standard_error
+      .show_stratum
+        == best_label_for 'population_t'
+        = @level.population_t
+      .show_stratum
+        == best_label_for 'population_degrees_of_freedom'
+        = @level.population_degrees_of_freedom
+      .show_stratum
+        == best_label_for 'population_confidence_interval'
+        = @level.population_confidence_interval
+      .show_stratum
+        == best_label_for 'population_lower_confidence_limit'
+        = @level.population_lower_confidence_limit
+      .show_stratum
+        == best_label_for 'population_upper_confidence_limit'
+        = @level.population_upper_confidence_limit
+      .show_stratum
+        == best_label_for 'population_no_precision_estimate_available'
+        = @level.population_no_precision_estimate_available
+      .show_stratum
+        == best_label_for 'method_of_analysis'
+        = @level.method_of_analysis
+      .show_stratum
+        == best_label_for 'area_calculation_method'
+        = @level.area_calculation_method
+      .show_stratum
+        == best_label_for 'genotypes_identified'
+        = @level.genotypes_identified
+      .show_stratum
+        == best_label_for 'samples_analyzed'
+        = @level.samples_analyzed
+      .show_stratum
+        == best_label_for 'sampling_locations'
+        = @level.sampling_locations
+      == map_stratum @level
 

--- a/app/views/survey_faecal_dnas/_form.html.slim
+++ b/app/views/survey_faecal_dnas/_form.html.slim
@@ -1,9 +1,0 @@
-.restated_survey_info
-  = render :partial => "submission_info", :locals => { :s => @submission }
-= semantic_form_for @survey_faecal_dna do |f|
-  = render "shared/error_messages", :target => @survey_faecal_dna
-  = f.inputs do
-    = f.input :population_submission_id, :as => :hidden, :value => @population_submission.id
-    = f.input :surveyed_at_stratum_level, :as => :hidden, :value => false
-    = f.input :stratum_level_data_submitted, :as => :hidden, :value => false
-  = f.buttons

--- a/app/views/survey_faecal_dnas/edit.html.slim
+++ b/app/views/survey_faecal_dnas/edit.html.slim
@@ -1,5 +1,0 @@
-h1= t '.title'
-p
-  = link_to t('back'), survey_faecal_dnas_path
-  = link_to t('show'), @survey_faecal_dna
-= render 'form'

--- a/app/views/survey_faecal_dnas/index.html.slim
+++ b/app/views/survey_faecal_dnas/index.html.slim
@@ -1,20 +1,22 @@
-h1= t('.title')
-p= link_to t('.new'), new_survey_faecal_dna_path
+.row
+  .col-xs-12
+    h1 = @title
+    p= link_to t('.new'), new_survey_faecal_dna_path
 
-table
-  thead
-    tr
-      th= SurveyFaecalDna.human_attribute_name :population_submission_id
-      th= SurveyFaecalDna.human_attribute_name :surveyed_at_stratum_level
-      th= SurveyFaecalDna.human_attribute_name :stratum_level_data_submitted
-      th colspan=3 = t 'actions'
-  
-  tbody
-    - for survey_faecal_dna in @survey_faecal_dnas
-      tr  class=cycle(:odd, :even)  
-        td= survey_faecal_dna.population_submission_id
-        td= survey_faecal_dna.surveyed_at_stratum_level
-        td= survey_faecal_dna.stratum_level_data_submitted
-        td.action= link_to t('show'), survey_faecal_dna
-        td.action= link_to t('edit'), edit_survey_faecal_dna_path(survey_faecal_dna)
-        td.action= link_to t('destroy'), survey_faecal_dna, :confirm => t('are_you_sure'), :method => :delete
+    table.table
+      thead
+        tr
+          th= SurveyFaecalDna.human_attribute_name :population_submission_id
+          th= SurveyFaecalDna.human_attribute_name :surveyed_at_stratum_level
+          th= SurveyFaecalDna.human_attribute_name :stratum_level_data_submitted
+          th colspan=3 = t 'actions'
+      
+      tbody
+        - for survey_faecal_dna in @survey_faecal_dnas
+          tr  class=cycle(:odd, :even)  
+            td= survey_faecal_dna.population_submission_id
+            td= survey_faecal_dna.surveyed_at_stratum_level
+            td= survey_faecal_dna.stratum_level_data_submitted
+            td.action= link_to t('show'), survey_faecal_dna
+            td.action= link_to t('edit'), edit_survey_faecal_dna_path(survey_faecal_dna)
+            td.action= link_to t('destroy'), survey_faecal_dna, :confirm => t('are_you_sure'), :method => :delete

--- a/app/views/survey_faecal_dnas/new.html.slim
+++ b/app/views/survey_faecal_dnas/new.html.slim
@@ -1,2 +1,0 @@
-h1= t '.title'
-= render 'form'

--- a/app/views/survey_faecal_dnas/show.html.slim
+++ b/app/views/survey_faecal_dnas/show.html.slim
@@ -1,5 +1,0 @@
-h1= t '.title'
-.restated_survey_info
-  = render :partial => "submission_info", :locals => { :s => @submission }
-== map_aggregate @level
-

--- a/app/views/survey_ground_sample_count_strata/_form.html.slim
+++ b/app/views/survey_ground_sample_count_strata/_form.html.slim
@@ -22,6 +22,4 @@
     -if current_user.admin?
       = f.input :is_mike_site, :as => :radio
       = f.input :mike_site
-  = f.buttons do
-    = f.commit_button :label => 'Save and enter another stratum'
-    = f.commit_button :label => 'This is my final stratum'
+  = render 'strata_actions', f: f

--- a/app/views/survey_ground_sample_count_strata/edit.html.slim
+++ b/app/views/survey_ground_sample_count_strata/edit.html.slim
@@ -1,5 +1,0 @@
-h1= t '.title'
-p
-  = link_to t('back'), survey_ground_sample_count_strata_path
-  = link_to t('show'), @survey_ground_sample_count_stratum
-= render 'form'

--- a/app/views/survey_ground_sample_count_strata/new.html.slim
+++ b/app/views/survey_ground_sample_count_strata/new.html.slim
@@ -1,2 +1,0 @@
-h1= t '.title'
-= render 'form'

--- a/app/views/survey_ground_sample_count_strata/show.html.slim
+++ b/app/views/survey_ground_sample_count_strata/show.html.slim
@@ -1,49 +1,51 @@
-h1= t '.title'
-.restated_survey_info
-  = render :partial => "submission_info", :locals => { :s => @submission }
-h4
-  - if @level.stratum_name == ''
-    .count_stratum_name Stratum ## @level.id 
-  - else
-    .count_stratum_name= @level.stratum_name
-.show_stratum
-  == best_label_for 'stratum_area'
-  = @level.stratum_area
-.show_stratum
-  == best_label_for 'population_estimate'
-  = @level.population_estimate
-.show_stratum
-  == best_label_for 'population_variance'
-  = @level.population_variance
-.show_stratum
-  == best_label_for 'population_standard_error'
-  = @level.population_standard_error
-.show_stratum
-  == best_label_for 'population_t'
-  = @level.population_t
-.show_stratum
-  == best_label_for 'population_degrees_of_freedom'
-  = @level.population_degrees_of_freedom
-.show_stratum
-  == best_label_for 'population_confidence_interval'
-  = @level.population_confidence_interval
-.show_stratum
-  == best_label_for 'population_lower_confidence_limit'
-  = @level.population_lower_confidence_limit
-.show_stratum
-  == best_label_for 'population_upper_confidence_limit'
-  = @level.population_upper_confidence_limit
-.show_stratum
-  == best_label_for 'population_no_precision_estimate_available'
-  = @level.population_no_precision_estimate_available
-.show_stratum
-  == best_label_for 'transects_covered'
-  = @level.transects_covered
-.show_stratum
-  == best_label_for 'transects_covered_total_length'
-  = @level.transects_covered_total_length
-.show_stratum
-  == best_label_for 'person_hours'
-  = @level.person_hours
-== map_stratum @level
+.row
+  .col-xs-12
+    h1= t '.title'
+    .restated_survey_info
+      = render :partial => "submission_info", :locals => { :s => @submission }
+    h4
+      - if @level.stratum_name.blank?
+        .count_stratum_name = "Stratum ##{@level.id}"
+      - else
+        .count_stratum_name= @level.stratum_name
+    .show_stratum
+      == best_label_for 'stratum_area'
+      = @level.stratum_area
+    .show_stratum
+      == best_label_for 'population_estimate'
+      = @level.population_estimate
+    .show_stratum
+      == best_label_for 'population_variance'
+      = @level.population_variance
+    .show_stratum
+      == best_label_for 'population_standard_error'
+      = @level.population_standard_error
+    .show_stratum
+      == best_label_for 'population_t'
+      = @level.population_t
+    .show_stratum
+      == best_label_for 'population_degrees_of_freedom'
+      = @level.population_degrees_of_freedom
+    .show_stratum
+      == best_label_for 'population_confidence_interval'
+      = @level.population_confidence_interval
+    .show_stratum
+      == best_label_for 'population_lower_confidence_limit'
+      = @level.population_lower_confidence_limit
+    .show_stratum
+      == best_label_for 'population_upper_confidence_limit'
+      = @level.population_upper_confidence_limit
+    .show_stratum
+      == best_label_for 'population_no_precision_estimate_available'
+      = @level.population_no_precision_estimate_available
+    .show_stratum
+      == best_label_for 'transects_covered'
+      = @level.transects_covered
+    .show_stratum
+      == best_label_for 'transects_covered_total_length'
+      = @level.transects_covered_total_length
+    .show_stratum
+      == best_label_for 'person_hours'
+      = @level.person_hours
+    == map_stratum @level
 

--- a/app/views/survey_ground_sample_counts/_form.html.slim
+++ b/app/views/survey_ground_sample_counts/_form.html.slim
@@ -1,9 +1,0 @@
-.restated_survey_info
-  = render :partial => "submission_info", :locals => { :s => @submission }
-= semantic_form_for @survey_ground_sample_count do |f|
-  = render "shared/error_messages", :target => @survey_ground_sample_count
-  = f.inputs do
-    = f.input :population_submission_id, :as => :hidden, :value => @population_submission.id
-    = f.input :surveyed_at_stratum_level, :as => :radio
-    = f.input :stratum_level_data_submitted, :as => :radio
-  = f.buttons

--- a/app/views/survey_ground_sample_counts/edit.html.slim
+++ b/app/views/survey_ground_sample_counts/edit.html.slim
@@ -1,5 +1,0 @@
-h1= t '.title'
-p
-  = link_to t('back'), survey_ground_sample_counts_path
-  = link_to t('show'), @survey_ground_sample_count
-= render 'form'

--- a/app/views/survey_ground_sample_counts/new.html.slim
+++ b/app/views/survey_ground_sample_counts/new.html.slim
@@ -1,2 +1,0 @@
-h1= t '.title'
-= render 'form'

--- a/app/views/survey_ground_sample_counts/show.html.slim
+++ b/app/views/survey_ground_sample_counts/show.html.slim
@@ -1,5 +1,0 @@
-h1= t '.title'
-.restated_survey_info
-  = render :partial => "submission_info", :locals => { :s => @submission }
-== map_aggregate @level
-

--- a/app/views/survey_ground_total_count_strata/_form.html.slim
+++ b/app/views/survey_ground_total_count_strata/_form.html.slim
@@ -16,6 +16,4 @@
     -if current_user.admin?
       = f.input :is_mike_site, :as => :radio
       = f.input :mike_site
-  = f.buttons do
-    = f.commit_button :label => 'Save and enter another stratum'
-    = f.commit_button :label => 'This is my final stratum'
+  = render 'strata_actions', f: f

--- a/app/views/survey_ground_total_count_strata/edit.html.slim
+++ b/app/views/survey_ground_total_count_strata/edit.html.slim
@@ -1,5 +1,0 @@
-h1= t '.title'
-p
-  = link_to t('back'), survey_ground_total_count_strata_path
-  = link_to t('show'), @survey_ground_total_count_stratum
-= render 'form'

--- a/app/views/survey_ground_total_count_strata/new.html.slim
+++ b/app/views/survey_ground_total_count_strata/new.html.slim
@@ -1,2 +1,0 @@
-h1= t '.title'
-= render 'form'

--- a/app/views/survey_ground_total_count_strata/show.html.slim
+++ b/app/views/survey_ground_total_count_strata/show.html.slim
@@ -1,34 +1,36 @@
-h1= t '.title'
-.restated_survey_info
-  = render :partial => "submission_info", :locals => { :s => @submission }
-h4
-  - if @level.stratum_name == ''
-    .count_stratum_name Stratum ## @level.id 
-  - else
-    .count_stratum_name= @level.stratum_name
-.show_stratum
-  == best_label_for 'stratum_area'
-  = @level.stratum_area
-.show_stratum
-  == best_label_for 'population_estimate'
-  = @level.population_estimate
-.show_stratum
-  == best_label_for 'transects_covered'
-  = @level.transects_covered
-.show_stratum
-  == best_label_for 'transects_covered_total_length'
-  = @level.transects_covered_total_length
-.show_stratum
-  == best_label_for 'person_hours'
-  = @level.person_hours
-.show_stratum
-  == best_label_for 'strip_width'
-  = @level.strip_width
-.show_stratum
-  == best_label_for 'observations'
-  = @level.observations
-.show_stratum
-  == best_label_for 'actually_seen'
-  = @level.actually_seen
-== map_stratum @level
+.row
+  .col-xs-12
+    h1= t '.title'
+    .restated_survey_info
+      = render :partial => "submission_info", :locals => { :s => @submission }
+    h4
+      - if @level.stratum_name.blank?
+        .count_stratum_name = "Stratum ##{@level.id}"
+      - else
+        .count_stratum_name= @level.stratum_name
+    .show_stratum
+      == best_label_for 'stratum_area'
+      = @level.stratum_area
+    .show_stratum
+      == best_label_for 'population_estimate'
+      = @level.population_estimate
+    .show_stratum
+      == best_label_for 'transects_covered'
+      = @level.transects_covered
+    .show_stratum
+      == best_label_for 'transects_covered_total_length'
+      = @level.transects_covered_total_length
+    .show_stratum
+      == best_label_for 'person_hours'
+      = @level.person_hours
+    .show_stratum
+      == best_label_for 'strip_width'
+      = @level.strip_width
+    .show_stratum
+      == best_label_for 'observations'
+      = @level.observations
+    .show_stratum
+      == best_label_for 'actually_seen'
+      = @level.actually_seen
+    == map_stratum @level
 

--- a/app/views/survey_ground_total_counts/_form.html.slim
+++ b/app/views/survey_ground_total_counts/_form.html.slim
@@ -1,9 +1,0 @@
-.restated_survey_info
-  = render :partial => "submission_info", :locals => { :s => @submission }
-= semantic_form_for @survey_ground_total_count do |f|
-  = render "shared/error_messages", :target => @survey_ground_total_count
-  = f.inputs do
-    = f.input :population_submission_id, :as => :hidden, :value => @population_submission.id
-    = f.input :surveyed_at_stratum_level, :as => :radio
-    = f.input :stratum_level_data_submitted, :as => :radio
-  = f.buttons

--- a/app/views/survey_ground_total_counts/edit.html.slim
+++ b/app/views/survey_ground_total_counts/edit.html.slim
@@ -1,5 +1,0 @@
-h1= t '.title'
-p
-  = link_to t('back'), survey_ground_total_counts_path
-  = link_to t('show'), @survey_ground_total_count
-= render 'form'

--- a/app/views/survey_ground_total_counts/new.html.slim
+++ b/app/views/survey_ground_total_counts/new.html.slim
@@ -1,2 +1,0 @@
-h1= t '.title'
-= render 'form'

--- a/app/views/survey_ground_total_counts/show.html.slim
+++ b/app/views/survey_ground_total_counts/show.html.slim
@@ -1,5 +1,0 @@
-h1= t '.title'
-.restated_survey_info
-  = render :partial => "submission_info", :locals => { :s => @submission }
-== map_aggregate @level
-

--- a/app/views/survey_individual_registrations/_form.html.slim
+++ b/app/views/survey_individual_registrations/_form.html.slim
@@ -13,4 +13,4 @@
     -if current_user.admin?
       = f.input :is_mike_site, :as => :radio
       = f.input :mike_site
-  = f.buttons
+  = f.actions

--- a/app/views/survey_individual_registrations/edit.html.slim
+++ b/app/views/survey_individual_registrations/edit.html.slim
@@ -1,5 +1,0 @@
-h1= t '.title'
-p
-  = link_to t('back'), survey_individual_registrations_path
-  = link_to t('show'), @survey_individual_registration
-= render 'form'

--- a/app/views/survey_individual_registrations/index.html.slim
+++ b/app/views/survey_individual_registrations/index.html.slim
@@ -1,26 +1,28 @@
-h1= t('.title')
-p= link_to t('.new'), new_survey_individual_registration_path
+.row
+  .col-xs-12
+    h1= t('.title')
+    p= link_to t('.new'), new_survey_individual_registration_path
 
-table
-  thead
-    tr
-      th= SurveyIndividualRegistration.human_attribute_name :population_submission_id
-      th= SurveyIndividualRegistration.human_attribute_name :population_estimate
-      th= SurveyIndividualRegistration.human_attribute_name :population_upper_range
-      th= SurveyIndividualRegistration.human_attribute_name :monitoring_years
-      th= SurveyIndividualRegistration.human_attribute_name :monitoring_frequency
-      th= SurveyIndividualRegistration.human_attribute_name :fenced_site
-      th colspan=3 = t 'actions'
-  
-  tbody
-    - for survey_individual_registration in @survey_individual_registrations
-      tr  class=cycle(:odd, :even)  
-        td= survey_individual_registration.population_submission_id
-        td= survey_individual_registration.population_estimate
-        td= survey_individual_registration.population_upper_range
-        td= survey_individual_registration.monitoring_years
-        td= survey_individual_registration.monitoring_frequency
-        td= survey_individual_registration.fenced_site
-        td.action= link_to t('show'), survey_individual_registration
-        td.action= link_to t('edit'), edit_survey_individual_registration_path(survey_individual_registration)
-        td.action= link_to t('destroy'), survey_individual_registration, :confirm => t('are_you_sure'), :method => :delete
+    table.table
+      thead
+        tr
+          th= SurveyIndividualRegistration.human_attribute_name :population_submission_id
+          th= SurveyIndividualRegistration.human_attribute_name :population_estimate
+          th= SurveyIndividualRegistration.human_attribute_name :population_upper_range
+          th= SurveyIndividualRegistration.human_attribute_name :monitoring_years
+          th= SurveyIndividualRegistration.human_attribute_name :monitoring_frequency
+          th= SurveyIndividualRegistration.human_attribute_name :fenced_site
+          th colspan=3 = t 'actions'
+      
+      tbody
+        - for survey_individual_registration in @survey_individual_registrations
+          tr  class=cycle(:odd, :even)  
+            td= survey_individual_registration.population_submission_id
+            td= survey_individual_registration.population_estimate
+            td= survey_individual_registration.population_upper_range
+            td= survey_individual_registration.monitoring_years
+            td= survey_individual_registration.monitoring_frequency
+            td= survey_individual_registration.fenced_site
+            td.action= link_to t('show'), survey_individual_registration
+            td.action= link_to t('edit'), edit_survey_individual_registration_path(survey_individual_registration)
+            td.action= link_to t('destroy'), survey_individual_registration, :confirm => t('are_you_sure'), :method => :delete

--- a/app/views/survey_individual_registrations/new.html.slim
+++ b/app/views/survey_individual_registrations/new.html.slim
@@ -1,2 +1,0 @@
-h1= t '.title'
-= render 'form'

--- a/app/views/survey_individual_registrations/show.html.slim
+++ b/app/views/survey_individual_registrations/show.html.slim
@@ -1,16 +1,18 @@
-h1= t '.title'
-.restated_survey_info
-  = render :partial => "submission_info", :locals => { :s => @submission }
-.show_stratum
-  == best_label_for 'monitoring_years'
-  = @level.monitoring_years
-.show_stratum
-  == best_label_for 'monitoring_frequency'
-  = @level.monitoring_frequency
-.show_stratum
-  == best_label_for 'fenced_site'
-  = @level.fenced_site
-.show_stratum
-  == best_label_for 'porous_fenced_site'
-  = @level.porous_fenced_site
-== map_stratum @level
+.row
+  .col-xs-12
+    h1 = @title
+    .restated_survey_info
+      = render :partial => "submission_info", :locals => { :s => @submission }
+    .show_stratum
+      == best_label_for 'monitoring_years'
+      = @level.monitoring_years
+    .show_stratum
+      == best_label_for 'monitoring_frequency'
+      = @level.monitoring_frequency
+    .show_stratum
+      == best_label_for 'fenced_site'
+      = @level.fenced_site
+    .show_stratum
+      == best_label_for 'porous_fenced_site'
+      = @level.porous_fenced_site
+    == map_stratum @level

--- a/app/views/survey_others/_form.html.slim
+++ b/app/views/survey_others/_form.html.slim
@@ -12,4 +12,4 @@
       = f.input :informed
       = f.input :is_mike_site, :as => :radio
       = f.input :mike_site
-  = f.buttons
+  = f.actions

--- a/app/views/survey_others/edit.html.slim
+++ b/app/views/survey_others/edit.html.slim
@@ -1,5 +1,0 @@
-h1= t '.title'
-p
-  = link_to t('back'), survey_others_path
-  = link_to t('show'), @survey_other
-= render 'form'

--- a/app/views/survey_others/index.html.slim
+++ b/app/views/survey_others/index.html.slim
@@ -1,22 +1,24 @@
-h1= t('.title')
-p= link_to t('.new'), new_survey_other_path
+.row
+  .col-xs-12
+    h1= t('.title')
+    p= link_to t('.new'), new_survey_other_path
 
-table
-  thead
-    tr
-      th= SurveyOther.human_attribute_name :population_submission_id
-      th= SurveyOther.human_attribute_name :other_method_description
-      th= SurveyOther.human_attribute_name :population_estimate_min
-      th= SurveyOther.human_attribute_name :population_estimate_max
-      th colspan=3 = t 'actions'
-  
-  tbody
-    - for survey_other in @survey_others
-      tr  class=cycle(:odd, :even)  
-        td= survey_other.population_submission_id
-        td= survey_other.other_method_description
-        td= survey_other.population_estimate_min
-        td= survey_other.population_estimate_max
-        td.action= link_to t('show'), survey_other
-        td.action= link_to t('edit'), edit_survey_other_path(survey_other)
-        td.action= link_to t('destroy'), survey_other, :confirm => t('are_you_sure'), :method => :delete
+    table.table
+      thead
+        tr
+          th= SurveyOther.human_attribute_name :population_submission_id
+          th= SurveyOther.human_attribute_name :other_method_description
+          th= SurveyOther.human_attribute_name :population_estimate_min
+          th= SurveyOther.human_attribute_name :population_estimate_max
+          th colspan=3 = t 'actions'
+      
+      tbody
+        - for survey_other in @survey_others
+          tr  class=cycle(:odd, :even)  
+            td= survey_other.population_submission_id
+            td= survey_other.other_method_description
+            td= survey_other.population_estimate_min
+            td= survey_other.population_estimate_max
+            td.action= link_to t('show'), survey_other
+            td.action= link_to t('edit'), edit_survey_other_path(survey_other)
+            td.action= link_to t('destroy'), survey_other, :confirm => t('are_you_sure'), :method => :delete

--- a/app/views/survey_others/new.html.slim
+++ b/app/views/survey_others/new.html.slim
@@ -1,2 +1,0 @@
-h1= t '.title'
-= render 'form'

--- a/app/views/survey_others/show.html.slim
+++ b/app/views/survey_others/show.html.slim
@@ -1,14 +1,16 @@
-h1= t '.title'
-.restated_survey_info
-  = render :partial => "submission_info", :locals => { :s => @submission }
-.show_stratum
-  == best_label_for 'other_method_description'
-  = @level.other_method_description
-.show_stratum
-  == best_label_for 'population_estimate_min'
-  = @level.population_estimate_min
-.show_stratum
-  == best_label_for 'population_estimate_max'
-  = @level.population_estimate_max
-== map_stratum @level
+.row
+  .col-xs-12
+    h1 = @title
+    .restated_survey_info
+      = render :partial => "submission_info", :locals => { :s => @submission }
+    .show_stratum
+      == best_label_for 'other_method_description'
+      = @level.other_method_description
+    .show_stratum
+      == best_label_for 'population_estimate_min'
+      = @level.population_estimate_min
+    .show_stratum
+      == best_label_for 'population_estimate_max'
+      = @level.population_estimate_max
+    == map_stratum @level
 

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -14,5 +14,5 @@
     = f.input :country
     - if current_user.admin?
       = f.input :admin
-  = f.buttons do
-    = f.commit_button :update
+  = f.actions do
+    = f.action :submit

--- a/app/views/users/edit.html.slim
+++ b/app/views/users/edit.html.slim
@@ -1,2 +1,4 @@
-h1 Editing user
-= render 'form'
+.row
+  .col-xs-12
+    h1 Editing user
+    = render 'form'

--- a/app/views/users/index.html.slim
+++ b/app/views/users/index.html.slim
@@ -1,20 +1,22 @@
-h1 Users
+.row
+  .col-xs-12
+    h1 Users
 
-=paginate @users
-table
-  tr
-    th Email
-    th Name
-    th Confirmed
-    th
-    th
-    th
-  - @users.each do |user|
-    tr
-      td= user.email
-      td= user.name
-      td= user.confirmed_at
-      td= link_to 'Show', user
-      td= link_to 'Edit', edit_user_path(user)
-      td= link_to t('destroy'), user, :confirm => "You are about to remove the user \"# user.email \". Do you wish to proceed?", :method => :delete
-br/
+    =paginate @users
+    table.table
+      tr
+        th Email
+        th Name
+        th Confirmed
+        th
+        th
+        th
+      - @users.each do |user|
+        tr
+          td= user.email
+          td= user.name
+          td= user.confirmed_at
+          td= link_to 'Show', user
+          td= link_to 'Edit', edit_user_path(user)
+          td= link_to t('destroy'), user, :confirm => "You are about to remove the user \"# user.email \". Do you wish to proceed?", :method => :delete
+    br/

--- a/app/views/users/new.html.slim
+++ b/app/views/users/new.html.slim
@@ -1,4 +1,6 @@
-h1 New user
+.row
+  .col-xs-12
+    h1 New user
 
-| Please have users self-register using the registration features of the site.
-| Do not create user accounts manually.
+    | Please have users self-register using the registration features of the site.
+    | Do not create user accounts manually.

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -1,28 +1,30 @@
-h1
-  = @user.email
-p
-  b Name:
-  = @user.name
-p
-  b Job Title:
-  = @user.job_title
-p
-  b Department:
-  = @user.department
-p
-  b Organization:
-  = @user.organization
-p
-  b Phone:
-  = @user.phone
-p
-  b Fax:
-  = @user.fax
-p
-  b Address:
-  = @user.address_1
-  = @user.address_2
-  = @user.address_3
-p
-  b City:
-  = @user.city
+.row
+  .col-xs-12
+    h1
+      = @user.email
+    p
+      b Name:
+      = @user.name
+    p
+      b Job Title:
+      = @user.job_title
+    p
+      b Department:
+      = @user.department
+    p
+      b Organization:
+      = @user.organization
+    p
+      b Phone:
+      = @user.phone
+    p
+      b Fax:
+      = @user.fax
+    p
+      b Address:
+      = @user.address_1
+      = @user.address_2
+      = @user.address_3
+    p
+      b City:
+      = @user.city

--- a/app/views/welcome/asian_range.html.slim
+++ b/app/views/welcome/asian_range.html.slim
@@ -1,3 +1,5 @@
-h1 Asian Elephant Range
+.row
+  .col-xs-12
+    h1 Asian Elephant Range
 
-= render 'asian_range'
+    = render 'asian_range'

--- a/app/views/welcome/index.html.slim
+++ b/app/views/welcome/index.html.slim
@@ -1,47 +1,46 @@
-.container
-  .row
-    .col-xs-12
-      .feature_name
-        | African Elephant Range (2014)
-      = map container_id: "leaflet_map", center: {latlng: [-12.04, 18.59], zoom: 4}
-      javascript:
-          var range_map = new L.geoJson();
-          //addition of scale
-          L.control.scale({position:'bottomleft', metric:true, imperial:false }).addTo(map);
-          //style
-          function style(feature) {
-            switch (feature.properties.RangeType) {
-              case 'Known': return {color: "#d94701","weight": 1,"opacity": 0.1,"fillColor": "#d94701","fillOpacity": 0.6};
-              case 'Possible': return {color: "#fd8d3c","weight": 5,"opacity": 0.1,"fillColor": "#fd8d3c","fillOpacity": 0.6};
-              case 'Doubtful': return {color: "#fdbe85","weight": 3,"opacity": 0.1,"fillColor": "#fdbe85","fillOpacity": 0.6};
-              case 'Non-range': return {color: "#feedde","weight": 3,"opacity": 0.1,"fillColor": "#feedde","fillOpacity": 0.6};
-            }
+.row
+  .col-xs-12
+    .feature_name
+      | African Elephant Range (2014)
+    = map container_id: "leaflet_map", center: {latlng: [-12.04, 18.59], zoom: 4}
+    javascript:
+        var range_map = new L.geoJson();
+        //addition of scale
+        L.control.scale({position:'bottomleft', metric:true, imperial:false }).addTo(map);
+        //style
+        function style(feature) {
+          switch (feature.properties.RangeType) {
+            case 'Known': return {color: "#d94701","weight": 1,"opacity": 0.1,"fillColor": "#d94701","fillOpacity": 0.6};
+            case 'Possible': return {color: "#fd8d3c","weight": 5,"opacity": 0.1,"fillColor": "#fd8d3c","fillOpacity": 0.6};
+            case 'Doubtful': return {color: "#fdbe85","weight": 3,"opacity": 0.1,"fillColor": "#fdbe85","fillOpacity": 0.6};
+            case 'Non-range': return {color: "#feedde","weight": 3,"opacity": 0.1,"fillColor": "#feedde","fillOpacity": 0.6};
           }
+        }
 
-          //legend display
-          var legend = L.control({position: 'bottomleft'});
-          legend.onAdd = function (map) {
-            var div = L.DomUtil.create('div', 'info legend');
-            div.innerHTML = "<i style='background:#d94701;'></i> Known Range" +
-                            "<br> <i style='background:#fd8d3c;'></i> Possible Range" +
-                            "<br> <i style='background:#fdbe85;'></i> Doubtful Range" +
-                            "<br> <i style='background:#feedde;'></i> Non Range";
-            return div;
+        //legend display
+        var legend = L.control({position: 'bottomleft'});
+        legend.onAdd = function (map) {
+          var div = L.DomUtil.create('div', 'info legend');
+          div.innerHTML = "<i style='background:#d94701;'></i> Known Range" +
+                          "<br> <i style='background:#fd8d3c;'></i> Possible Range" +
+                          "<br> <i style='background:#fdbe85;'></i> Doubtful Range" +
+                          "<br> <i style='background:#feedde;'></i> Non Range";
+          return div;
+        }
+        legend.addTo(map);
+
+        function onEachFeature(feature, layer) {
+          var popupContent = "<b>Country</b>: " +  feature.properties.CNTRYNAME + "<br><b>Type of range</b>: " +  feature.properties.RangeType
+          if (feature.properties.AREA_SQKM){
+            popupContent += "<br><b>Range Area</b>: " + feature.properties.AREA_SQKM  + ' km²';
           }
-          legend.addTo(map);
-
-          function onEachFeature(feature, layer) {
-            var popupContent = "<b>Country</b>: " +  feature.properties.CNTRYNAME + "<br><b>Type of range</b>: " +  feature.properties.RangeType
-            if (feature.properties.AREA_SQKM){
-              popupContent += "<br><b>Range Area</b>: " + feature.properties.AREA_SQKM  + ' km²';
-            }
-            if (feature.properties.PHENOTYPE){
-              popupContent += "<br><b>Phenotype</b>: " + feature.properties.PHENOTYPE;
-            }
-            layer.bindPopup(popupContent);
+          if (feature.properties.PHENOTYPE){
+            popupContent += "<br><b>Phenotype</b>: " + feature.properties.PHENOTYPE;
           }
+          layer.bindPopup(popupContent);
+        }
 
-          $.getJSON("/current_range_map.geojson", function(data) {
-            var range_map = L.geoJson(data, {style: style, onEachFeature: onEachFeature});
-            range_map.addTo(map);
-          });
+        $.getJSON("/current_range_map.geojson", function(data) {
+          var range_map = L.geoJson(data, {style: style, onEachFeature: onEachFeature});
+          range_map.addTo(map);
+        });

--- a/app/views/welcome/maps.html.slim
+++ b/app/views/welcome/maps.html.slim
@@ -1,16 +1,18 @@
-h1 Maps
-.gallery_item
-  .link= link_to 'AESR 2007 Input Zones', '/maps/zones'
-  .description All survey zones incorporated in the 2007 African Elephant Status Report
+.row
+  .col-xs-12
+    h1 Maps
+    .gallery_item
+      .link= link_to 'AESR 2007 Input Zones', '/maps/zones'
+      .description All survey zones incorporated in the 2007 African Elephant Status Report
 
-.gallery_item
-  .link= link_to 'AESR 2007 Range', '/maps/range'
-  .description Known and possible African Elephant range as shared in the 2007 African Elephant Specialist Report
+    .gallery_item
+      .link= link_to 'AESR 2007 Range', '/maps/range'
+      .description Known and possible African Elephant range as shared in the 2007 African Elephant Specialist Report
 
-.gallery_item
-  .link= link_to 'Asian Elephant Range', '/maps/asian_range'
-  .description Confirmed, possible, and recoverable Asian Elephant range from 2009 AsESG workshop
+    .gallery_item
+      .link= link_to 'Asian Elephant Range', '/maps/asian_range'
+      .description Confirmed, possible, and recoverable Asian Elephant range from 2009 AsESG workshop
 
-.gallery_item
-  .link= link_to 'African Elephant Observations', 'http://www.inaturalist.org/taxa/43694-Loxodonta-africana/map#3.59/-9.66/14.65', :target => '_blank'
-  .description Sightings of individual African Elephants - powered by iNaturalist
+    .gallery_item
+      .link= link_to 'African Elephant Observations', 'http://www.inaturalist.org/taxa/43694-Loxodonta-africana/map#3.59/-9.66/14.65', :target => '_blank'
+      .description Sightings of individual African Elephants - powered by iNaturalist

--- a/app/views/welcome/mike_report.html.slim
+++ b/app/views/welcome/mike_report.html.slim
@@ -1,14 +1,16 @@
-h1 Changes Since 2007 Impacting MIKE Sites
+.row
+  .col-xs-12
+    h1 Changes Since 2007 Impacting MIKE Sites
 
-table
-  tr
-    th MIKE ID
-    th AESR 2007 Data
-    th Reason for Change
-    th Latest Data
-  - @changes.each do |row|
-    tr
-      td= row['mike_site']
-      td== enumerate_oids(row['aed2007_oids'])
-      td= row['reason_change']
-      td== enumerate_strata(row['current_strata'])
+    table.table
+      tr
+        th MIKE ID
+        th AESR 2007 Data
+        th Reason for Change
+        th Latest Data
+      - @changes.each do |row|
+        tr
+          td= row['mike_site']
+          td== enumerate_oids(row['aed2007_oids'])
+          td= row['reason_change']
+          td== enumerate_strata(row['current_strata'])

--- a/app/views/welcome/range.html.slim
+++ b/app/views/welcome/range.html.slim
@@ -1,5 +1,7 @@
-h1 AESR 2007 Range
+.row
+  .col-xs-12
+    h1 AESR 2007 Range
 
-= render 'range'
+    = render 'range'
 
-div= link_to 'Network linked KML', 'https://www.google.com/fusiontables/exporttable?query=select+col3+from+2899026+&o=kmllink&g=col3'
+    div= link_to 'Network linked KML', 'https://www.google.com/fusiontables/exporttable?query=select+col3+from+2899026+&o=kmllink&g=col3'

--- a/app/views/welcome/reliability.html.slim
+++ b/app/views/welcome/reliability.html.slim
@@ -1,90 +1,92 @@
-h1 Survey Reliability
+.row
+  .col-xs-12
+    h1 Survey Reliability
 
-| Categorization of elephant population estimates according to survey type and contribution of each to the four categories of elephant numbers.
+    p.lead Categorization of elephant population estimates according to survey type and contribution of each to the four categories of elephant numbers.
 
-table.survey_reliability
-  tr
-    td <b>Survey Reliability</b>
-    td <b>Survey type(s)</b>
-    td <b>Categorization of estimates</b>
-  tr
-    td A
-    td 
-      | * INDIVIDUAL REGISTRATIONS (IR)
-      br
-      | * AERIAL TOTAL COUNTS (AT)
-      br
-      | * GROUND TOTAL COUNTS (GT)
-    td
-      | DEFINITE = the population estimate.
-      br
-      | PROBABLE = none.
-      br
-      | POSSIBLE = none.
-      br
-      | SPECULATIVE = none.
-  tr
-    td B
-    td
-      | * AERIAL SAMPLE COUNTS (AS)or GROUND SAMPLE COUNTS (GS) with 95% confidence limits
-      br
-      | * DUNG COUNTS (DC) with 95% confidence limits and an estimate of dung decay rate obtained on site
-    td
-      | DEFINITE = the lower 95% confidence limit of the population estimate (there are at least this number of elephants) or the number actually seen, whichever is greater.
-      br
-      | PROBABLE = the difference<sup>a</sup> between the estimate and the lower confidence limit, or between the estimate and the actual number seen or between the estimate and zero, if the lower confidence limit is negative<sup>b</sup>.
-      br
-      | POSSIBLE = the difference between the upper confidence limit and the estimate.
-      br
-      | SPECULATIVE = none.
-  tr
-    td C
-    td
-      | * DUNG COUNTS (DC) with 95% confidence limits but no on-site measurement of dung decay rate
-      br
-      | * GENETIC DUNG COUNTS (GD)
-    td
-      | DEFINITE = none, or the number actually seen, if given<sup>c</sup>.
-      br
-      | PROBABLE = the population estimate.
-      br
-      | POSSIBLE = the difference between the upper confidence limit and the estimate.
-      br
-      | SPECULATIVE = none.
-  tr
-    td D
-    td
-      | * AERIAL SAMPLE COUNTS (AS), GROUND SAMPLE COUNTS (GS) and DUNG COUNTS (DC) without 95% confidence limits
-      br
-      | * INFORMED GUESSES (IG)
-    td
-      | DEFINITE = the number actually seen, if given.
-      br
-      | PROBABLE = none.
-      br
-      | POSSIBLE = the population estimate or the lower estimate if a range is given, minus the actual number seen, if given.
-      br
-      | SPECULATIVE = the difference between upper and lower estimates, if given
-  tr
-    td E
-    td
-      | * OTHER GUESSES (OG)
-      br
-      | * Any of the above survey types in which the estimate is over 10 years old
-    td  
-      | DEFINITE = the number actually seen, if given.
-      br
-      | PROBABLE = none.
-      br
-      | POSSIBLE = none.
-      br
-      | SPECULATIVE = the estimate, or the mean of the upper and lower limit, minus the actual number seen, if given.
+    table.table.survey_reliability
+      tr
+        td <b>Survey Reliability</b>
+        td <b>Survey type(s)</b>
+        td <b>Categorization of estimates</b>
+      tr
+        td A
+        td 
+          | * INDIVIDUAL REGISTRATIONS (IR)
+          br
+          | * AERIAL TOTAL COUNTS (AT)
+          br
+          | * GROUND TOTAL COUNTS (GT)
+        td
+          | DEFINITE = the population estimate.
+          br
+          | PROBABLE = none.
+          br
+          | POSSIBLE = none.
+          br
+          | SPECULATIVE = none.
+      tr
+        td B
+        td
+          | * AERIAL SAMPLE COUNTS (AS)or GROUND SAMPLE COUNTS (GS) with 95% confidence limits
+          br
+          | * DUNG COUNTS (DC) with 95% confidence limits and an estimate of dung decay rate obtained on site
+        td
+          | DEFINITE = the lower 95% confidence limit of the population estimate (there are at least this number of elephants) or the number actually seen, whichever is greater.
+          br
+          | PROBABLE = the difference<sup>a</sup> between the estimate and the lower confidence limit, or between the estimate and the actual number seen or between the estimate and zero, if the lower confidence limit is negative<sup>b</sup>.
+          br
+          | POSSIBLE = the difference between the upper confidence limit and the estimate.
+          br
+          | SPECULATIVE = none.
+      tr
+        td C
+        td
+          | * DUNG COUNTS (DC) with 95% confidence limits but no on-site measurement of dung decay rate
+          br
+          | * GENETIC DUNG COUNTS (GD)
+        td
+          | DEFINITE = none, or the number actually seen, if given<sup>c</sup>.
+          br
+          | PROBABLE = the population estimate.
+          br
+          | POSSIBLE = the difference between the upper confidence limit and the estimate.
+          br
+          | SPECULATIVE = none.
+      tr
+        td D
+        td
+          | * AERIAL SAMPLE COUNTS (AS), GROUND SAMPLE COUNTS (GS) and DUNG COUNTS (DC) without 95% confidence limits
+          br
+          | * INFORMED GUESSES (IG)
+        td
+          | DEFINITE = the number actually seen, if given.
+          br
+          | PROBABLE = none.
+          br
+          | POSSIBLE = the population estimate or the lower estimate if a range is given, minus the actual number seen, if given.
+          br
+          | SPECULATIVE = the difference between upper and lower estimates, if given
+      tr
+        td E
+        td
+          | * OTHER GUESSES (OG)
+          br
+          | * Any of the above survey types in which the estimate is over 10 years old
+        td  
+          | DEFINITE = the number actually seen, if given.
+          br
+          | PROBABLE = none.
+          br
+          | POSSIBLE = none.
+          br
+          | SPECULATIVE = the estimate, or the mean of the upper and lower limit, minus the actual number seen, if given.
 
-.survey_reliability
-  | a. Rounded to the nearest whole number if necessary.
-  br
-  | b. If the lower confidence limit of the estimate is a negative figure, the estimate will be zero or, if reported, the actual number of elephants seen in the survey.
-  br
-  | c. For dung counts it is assumed that there are no elephants unless any are observed directly (which is seldom the case). This is because, unlike with aerial surveys, where the estimate is almost invariably lower than the true population size, dung counts may underestimate or overestimate the population size, depending on the choice of parameters used (such as forest area, decay rate, or the mathematical model used). For genetic dung counts (GD) the number of distinct genotypes identified is regarded as the number of elephants actually “seen”.
+    .survey_reliability
+      | a. Rounded to the nearest whole number if necessary.
+      br
+      | b. If the lower confidence limit of the estimate is a negative figure, the estimate will be zero or, if reported, the actual number of elephants seen in the survey.
+      br
+      | c. For dung counts it is assumed that there are no elephants unless any are observed directly (which is seldom the case). This is because, unlike with aerial surveys, where the estimate is almost invariably lower than the true population size, dung counts may underestimate or overestimate the population size, depending on the choice of parameters used (such as forest area, decay rate, or the mathematical model used). For genetic dung counts (GD) the number of distinct genotypes identified is regarded as the number of elephants actually “seen”.
 
 

--- a/app/views/welcome/zones.html.slim
+++ b/app/views/welcome/zones.html.slim
@@ -1,3 +1,5 @@
-h1 AESR 2007 Survey Zones
+.row
+  .col-xs-12
+    h1 AESR 2007 Survey Zones
 
-= render 'zones'
+    = render 'zones'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -368,6 +368,31 @@ en:
   new_survey_ground_total_block: "New Ground Total Block"
   new_point_observation: "New point observation"
   all_submissions: "All Submissions"
+  footnotes:
+    iqi:
+      "IQI: Information Quality Index: This index quantifies overall data quality at the regional level based on the 
+      precision of estimates and the proportion of assessed elephant range (i.e. range for which estimates are available). 
+      The IQI ranges from zero (no reliable information) to one (perfect information)."
+    causes_of_change:
+      "Key to Causes of Change (only tracked since 2007): DA: Different Area; DD: Data Degraded; DT: Different Technique; 
+      NA: New Analysis; NG: New Guess; NP: New population; PL: Population Lost; RS: Repeat Survey (RS ́ denotes a repeat 
+      survey that is not statistically comparable for reasons such as different season); –––: No Change"
+    survey_types:
+      "Key to Survey Types: AC: Aerial Count, not specified; AS: Aerial Sample Count; AT: Aerial Total Count; DC: Dung 
+      Count; EX: Extrapolation from GIS; GD: Genetic Dung Count; GS: Ground Sample Count; GT: Ground Total Count; IG: 
+      Informed Guess; IR: Individual Registration; OG: Other Guess. Survey Type is followed by an indicator of survey quality, 
+      ranked from 1 to 3 (best to worst). Survey Reliability is keyed A-E (best to worst) as <a href='/reliability'>outlined 
+      in this table</a>."
+    pfs:
+      "PFS: Priority for Future Surveys, ranked from 1 to 5 (highest to lowest). Based on the precision of 
+      estimates and the proportion of national range accounted for by the site in question, PFS is a measure 
+      of the importance and urgency for future population surveys. All areas of unassessed range have a priority 
+      of 1. See Introduction for details on how the PFS is derived."
+    derived_warning:
+      "Note that totals for the Definite, Probable, and Possible categories are derived by pooling the variances of 
+      individual estimates, as described at <a href='http://www.elephantdatabase.org/reliability'>
+      http://www.elephantdatabase.org/reliability</a>. As a result, totals do not necessarily match the simple 
+      sum of the entries within a given category."
   embargoed_until: 
     <strong>Embargoed until</strong><br/> Your survey data will be used to create pooled estimates at the national, 
     sub-regional and continental level, and any GIS boundaries will be used for making maps of elephant 


### PR DESCRIPTION
Following a toolchain upgrade, views have been reviewed,
corrected, and, when possible, DRYed up, in order to make
the site functional again.

Note that some views need polish in terms of design, but all
should be functional and code should be in a state where we
aren't cleaning the same thing multiple times.

Major notes:

* Fixed login issue with new Devise
* Devise views updated to use @token for mailers
* Main layouts updated to use proper container/row/col format
* Reporting views cleaned up, split into partials
* New breadcrumbs view for reports, preview reports
* Removed excess views from survey/count CRUD, use single
  layout whenever possible
* Moved some repeated text into en.yml, particularly footnotes