### PR TITLE
DPPS Reporting + Proof of Concept

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ log/*.log
 tmp/
 .sass-cache/
 public/assets
+public/uploads
 /config/database.yml

--- a/Gemfile
+++ b/Gemfile
@@ -84,6 +84,7 @@ group :development do
 end
 
 group :development, :test do
+  gem 'roo'
   gem 'ruby_parser'
   gem 'hpricot'
 end

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -1,4 +1,5 @@
 class ReportController < ApplicationController
+  include AltDppsHelper
 
   before_filter :set_past_years
 
@@ -162,6 +163,9 @@ class ReportController < ApplicationController
     @continent = params[:continent]
     @filter = params[:filter]
     @preview_title = official_title(@filter) or @filter.humanize.upcase
+
+    @alt_summary_totals = execute alt_dpps("1=1", @year, @filter)
+    @alt_areas          = execute alt_dpps_area("1=1", @year, @filter)
 
     @summary_totals_by_continent = execute totalizer("1=1",@filter,@year)
     @baseline_total = execute <<-SQL, @continent
@@ -337,6 +341,9 @@ class ReportController < ApplicationController
     @filter = params[:filter]
     @preview_title = official_title(@filter) or @filter.humanize.upcase
 
+    @alt_summary_totals = execute alt_dpps("r.name = '#{@region}'", @year, @filter)
+    @alt_areas          = execute alt_dpps_area("region = '#{@region}'", @year, @filter)
+
     @summary_totals_by_region = execute totalizer("region='#{@region}'",@filter,@year)
     @baseline_total = execute <<-SQL, @region
       select sum(definite) definite, sum(probable) probable, sum(possible) possible,
@@ -505,6 +512,9 @@ class ReportController < ApplicationController
     @country = params[:country].gsub('_',' ')
     @filter = params[:filter]
     @preview_title = official_title(@filter) or @filter.humanize.upcase
+
+    @alt_summary_totals = execute alt_dpps("c.name = '#{sql_escape @country}'", @year, @filter)
+    @alt_areas          = execute alt_dpps_area("country = '#{sql_escape @country}'", @year, @filter)
 
     @baseline_total = execute <<-SQL, @country
       select sum(definite) definite, sum(probable) probable, sum(possible) possible,

--- a/app/controllers/spreadsheets_controller.rb
+++ b/app/controllers/spreadsheets_controller.rb
@@ -1,0 +1,88 @@
+require 'roo'
+
+class SpreadsheetsController < ApplicationController
+  include AltDppsHelper
+  include SpreadsheetsHelper
+
+  before_filter :authenticate_user!
+  before_filter :ensure_admin!
+
+  def index
+    @files = Dir.glob("#{directory}/*")
+    @sheets = []
+
+    @files.each do |file|
+      @sheets << { name: File.basename(file), created_at: File.mtime(file) }
+    end
+  end
+
+  def create
+    file      = params[:file]
+    name      = file.original_filename
+
+    FileUtils.mkdir_p(directory) unless File.exists?(directory)
+    path = File.join(directory, name)
+
+    File.open(path, 'wb') do |f|
+      f.write file.read
+    end
+
+    redirect_to spreadsheet_path(name)
+  end
+
+  def show
+    path  = File.join directory, "#{params[:id]}.#{params[:format]}"
+    @xlsx = Roo::Spreadsheet.open(path)
+
+    data_point_cols = { 'CATEGORY' => 0, 'ESTIMATE' => 1, 'CONFIDENCE' => 2, 'GUESS_MIN' => 3, 'GUESS_MAX' => 4, 'RANGE' => 5 }
+
+    categories = {}
+    categories['Aerial or Ground Total Counts'.downcase] = 'A'
+    categories['Direct Sample Counts and Reliable Dung Counts'.downcase] = 'B'
+    categories['Other Dung Counts'.downcase] = 'C'
+    categories['Informed Guesses'.downcase] = 'D'
+    categories['Other guesses'.downcase] = 'E'
+    categories['Data Degraded'.downcase] = 'F'
+    categories['Modeled Extrapolation'.downcase] = 'G'
+
+    @targets = { 'WA_NoRounding' => 'West_Africa', 'CA_NoRounding' => 'Central_Africa', 'EA_NoRounding' => 'Eastern_Africa' }
+    @sheets  = []
+
+    @targets.each do |name, region|
+      sheet = @xlsx.sheet_for name
+      if sheet
+        data = {}
+        sheet.each_row(offset: sheet.first_row) do |row|
+          if row[0]
+            category = row[0].value.downcase rescue nil
+            if categories[category]
+              h = {}
+              data_point_cols.each do |data_point, col|
+                h[data_point] = row[col].nil?? nil : row[col].value
+              end
+              data[categories[category]] = h
+            end
+          end
+        end
+
+        @sheets << { name: name, sheet: sheet, expected: data, actual: hash_tuples(execute(alt_dpps("r.name = '#{region.gsub('_',' ')}'", 2013, '2013_africa_final'))) }
+      end
+    end
+  end
+
+  private
+
+  def directory
+    File.join Rails.root, 'public', 'uploads', 'spreadsheets'
+  end
+
+  def ensure_admin!
+    not_allowed! unless current_user.admin?
+  end
+
+  def execute(*array)
+    sql = ActiveRecord::Base.send(:sanitize_sql_array, array)
+    return ActiveRecord::Base.connection.execute(sql)
+  end
+
+end

--- a/app/helpers/alt_dpps_helper.rb
+++ b/app/helpers/alt_dpps_helper.rb
@@ -1,0 +1,293 @@
+module AltDppsHelper
+
+  @@blank_cells = nil
+
+  def unused_cell
+    '&mdash;'.html_safe
+  end
+
+  def rounded number
+    case number
+    when 0..4 then number.round
+    when 5..1000 then number.round(-1)
+    else number.round(-2)
+    end
+  end
+
+  def round_area area
+    area.to_f.round(1)
+  end
+
+  def is_blank_cell? row, column
+    @@blank_cells ||= {
+      'A': ['CONFIDENCE', 'GUESS_MIN', 'GUESS_MAX'],
+      'B': ['GUESS_MIN', 'GUESS_MAX'],
+      'C': ['CONFIDENCE'],
+      'D': ['CONFIDENCE'],
+      'E': ['CONFIDENCE'],
+      'F': ['ESTIMATE', 'CONFIDENCE'],
+      'G': ['ESTIMATE', 'CONFIDENCE']
+    }
+
+    values = @@blank_cells[row['CATEGORY'].to_sym]
+    return !values.nil? && values.include?(column)
+  end
+
+  def add_and_display_area row, column, totals
+    totals[column] ||= 0
+    value = row[column] || 0
+    if value.nil?
+      unused_cell
+    else
+      num = value.to_f
+      totals[column] += num
+      round_area num
+    end
+  end
+
+  def add_and_display row, column, totals, round=false
+    totals[column] ||= 0
+    value = row[column]
+    if value.nil? || is_blank_cell?(row, column)
+      unused_cell
+    else
+      num = value.to_i
+      totals[column] += num
+      number_with_delimiter(round ? rounded(num) : num)
+    end
+  end
+
+  def alt_dpps_area scope, year, filter=nil
+    analysis_name = filter.nil?? '' : "AND analysis_name = '#{filter}'"
+    <<-SQL
+      SELECT 
+        a.category,
+        a."AREA",
+        a."AREA" / rt.range_area * 100 as "CATEGORY_RANGE_ASSESSED",
+        rt.range_area,
+        rt.percent_range_assessed
+      FROM (
+        SELECT
+          category, region, sum(area_sqkm) as "AREA"
+        FROM
+          survey_range_intersection_metrics sm
+        WHERE
+          analysis_year = #{@year}
+          #{analysis_name}
+          AND #{scope}
+        GROUP BY category, region
+      ) a
+      JOIN regional_range_totals rt ON rt.region = a.region
+      ORDER BY category
+    SQL
+  end
+
+  def alt_dpps scope, year, filter=nil
+    analysis_name = filter.nil?? '' : "AND e.analysis_name = '#{filter}'"
+    <<-SQL
+      SELECT
+        e.category as "CATEGORY",
+        surveytype as "SURVEYTYPE",
+        sum(e.population_estimate) as "ESTIMATE",
+        0 as "CONFIDENCE",
+        0 as "GUESS_MIN",
+        0 as "GUESS_MAX",
+        sum(ps.area) as "AREA"
+      FROM
+        estimate_factors_analyses_categorized e
+      JOIN population_submissions ps ON ps.id = e.population_submission_id
+      JOIN submissions s ON ps.submission_id = s.id
+      JOIN countries c ON s.country_id = c.id
+      JOIN regions r ON c.region_id = r.id
+      JOIN surveytypes st ON e.category = st.category
+      WHERE 
+        e.analysis_year = #{year}
+        #{analysis_name}
+        AND e.category = 'A'
+        AND #{scope}
+      GROUP BY "CATEGORY", "SURVEYTYPE"
+
+      UNION
+
+      SELECT
+        e.category as "CATEGORY",
+        surveytype as "SURVEYTYPE",
+        sum(e.population_estimate) as "ESTIMATE",
+        1.96*sqrt(sum(e.population_variance)) as "CONFIDENCE",
+        0 as "GUESS_MIN",
+        0 as "GUESS_MAX",
+        sum(ps.area) as "AREA"
+      FROM
+        estimate_factors_analyses_categorized e
+      JOIN population_submissions ps ON ps.id = e.population_submission_id
+      JOIN submissions s ON ps.submission_id = s.id
+      JOIN countries c ON s.country_id = c.id
+      JOIN regions r ON c.region_id = r.id
+      JOIN surveytypes st ON e.category = st.category
+      WHERE 
+        e.analysis_year = #{year}
+        #{analysis_name}
+        AND e.category = 'B'
+        AND #{scope}
+      GROUP BY "CATEGORY", "SURVEYTYPE"
+
+      UNION
+
+      SELECT
+        e.category as "CATEGORY",
+        surveytype as "SURVEYTYPE",
+        sum(e.actually_seen) as "ESTIMATE",
+        0 as "CONFIDENCE",
+        sum(e.population_estimate) - sum(e.actually_seen) as "GUESS_MIN",
+        sum(e.population_estimate) - sum(e.actually_seen) as "GUESS_MAX",
+        sum(ps.area) as "AREA"
+      FROM
+        estimate_factors_analyses_categorized e
+      JOIN population_submissions ps ON ps.id = e.population_submission_id
+      JOIN submissions s ON ps.submission_id = s.id
+      JOIN countries c ON s.country_id = c.id
+      JOIN regions r ON c.region_id = r.id
+      JOIN surveytypes st ON e.category = st.category
+      WHERE 
+        e.analysis_year = #{year}
+        #{analysis_name}
+        AND e.category = 'C'
+        AND #{scope}
+      GROUP BY "CATEGORY", "SURVEYTYPE"
+
+      UNION
+
+      SELECT
+        e.category as "CATEGORY",
+        surveytype as "SURVEYTYPE",
+        sum(e.actually_seen) as "ESTIMATE",
+        0 as "CONFIDENCE",
+        sum(e.population_lower_confidence_limit) - sum(e.actually_seen) as "GUESS_MIN",
+        sum(e.population_upper_confidence_limit) - sum(e.actually_seen) as "GUESS_MAX",
+        sum(ps.area) as "AREA"
+      FROM
+        estimate_factors_analyses_categorized e
+      JOIN population_submissions ps ON ps.id = e.population_submission_id
+      JOIN submissions s ON ps.submission_id = s.id
+      JOIN countries c ON s.country_id = c.id
+      JOIN regions r ON c.region_id = r.id
+      JOIN surveytypes st ON e.category = st.category
+      WHERE 
+        e.analysis_year = #{year}
+        #{analysis_name}
+        AND e.category = 'D'
+        AND #{scope}
+      GROUP BY "CATEGORY", "SURVEYTYPE"
+
+      UNION
+
+      SELECT
+        e.category as "CATEGORY",
+        surveytype as "SURVEYTYPE",
+        sum(e.actually_seen) as "ESTIMATE",
+        0 as "CONFIDENCE",
+        sum(e.population_lower_confidence_limit) - sum(e.actually_seen) as "GUESS_MIN",
+        sum(e.population_upper_confidence_limit) - sum(e.actually_seen) as "GUESS_MAX",
+        sum(ps.area) as "AREA"
+      FROM
+        estimate_factors_analyses_categorized e
+      JOIN population_submissions ps ON ps.id = e.population_submission_id
+      JOIN submissions s ON ps.submission_id = s.id
+      JOIN countries c ON s.country_id = c.id
+      JOIN regions r ON c.region_id = r.id
+      JOIN surveytypes st ON e.category = st.category
+      WHERE 
+        e.analysis_year = #{year}
+        #{analysis_name}
+        AND e.completion_year > #{year - 10}
+        AND e.category = 'E'
+        AND #{scope}
+      GROUP BY "CATEGORY", "SURVEYTYPE"
+
+      UNION
+
+      SELECT
+        'F' as "CATEGORY",
+        'Data degraded' as "SURVEYTYPE",
+        0 as "ESTIMATE",
+        0 as "CONFIDENCE",
+        sum(e.population_estimate) as "GUESS_MIN",
+        sum(e.population_estimate) as "GUESS_MAX",
+        sum(ps.area) as "AREA"
+      FROM
+        estimate_factors_analyses_categorized e
+      JOIN population_submissions ps ON ps.id = e.population_submission_id
+      JOIN submissions s ON ps.submission_id = s.id
+      JOIN countries c ON s.country_id = c.id
+      JOIN regions r ON c.region_id = r.id
+      JOIN surveytypes st ON e.category = st.category
+      WHERE 
+        e.analysis_year = #{year}
+        #{analysis_name}
+        AND e.completion_year <= #{year - 10}
+        AND e.category = 'E'
+        AND #{scope}
+      GROUP BY "CATEGORY", "SURVEYTYPE"
+
+      UNION
+
+      SELECT
+        'G' as "CATEGORY",
+        'Modeled Extrapolation' as "SURVEYTYPE",
+        0 as "ESTIMATE",
+        0 as "CONFIDENCE",
+        sum(e.population_estimate) as "GUESS_MIN",
+        sum(e.population_estimate) as "GUESS_MAX",
+        sum(ps.area) as "AREA"
+      FROM
+        estimate_factors_analyses_categorized e
+      JOIN population_submissions ps ON ps.id = e.population_submission_id
+      JOIN submissions s ON ps.submission_id = s.id
+      JOIN countries c ON s.country_id = c.id
+      JOIN regions r ON c.region_id = r.id
+      JOIN surveytypes st ON e.category = st.category
+      WHERE
+        e.analysis_year = #{year}
+        #{analysis_name}
+        AND e.category = 'D'
+        AND e.site_name = 'Rest of Gabon'
+        AND #{scope}
+
+      ORDER BY "CATEGORY"
+    SQL
+  end
+
+  def old_alt_dpps scope, year
+    <<-SQL
+      SELECT 
+        CASE
+          WHEN e.completion_year > #{year - 10} THEN e.category
+          ELSE 'F'
+        END "CATEGORY",
+        CASE
+          WHEN e.completion_year > #{year - 10} THEN surveytype
+          ELSE 'Data degraded'
+        END "SURVEYTYPE",
+        sum(e.actually_seen) as seen, 
+        sum(e.population_estimate) as estimate,
+        sum(e.population_lower_confidence_limit) as min,
+        sum(e.population_upper_confidence_limit) as max,
+        1.96*sqrt(sum(e.population_variance)) as confidence,
+        sum(e.population_variance) as var,
+        sum(e.stratum_area) as area
+      FROM
+        estimate_factors_analyses_categorized e
+      JOIN population_submissions ps ON ps.id = e.population_submission_id
+      JOIN submissions s ON ps.submission_id = s.id
+      JOIN countries c ON s.country_id = c.id
+      JOIN regions r ON c.region_id = r.id
+      JOIN surveytypes st ON e.category = st.category
+      WHERE 
+        e.analysis_year = #{year} 
+        AND #{scope}
+      GROUP BY "CATEGORY", "SURVEYTYPE"
+      ORDER BY "CATEGORY"
+    SQL
+  end
+
+end

--- a/app/helpers/spreadsheets_helper.rb
+++ b/app/helpers/spreadsheets_helper.rb
@@ -1,0 +1,11 @@
+module SpreadsheetsHelper
+
+  def hash_tuples result
+    hash = {}
+    result.each do |row|
+      hash[row['CATEGORY']] = row
+    end
+    hash
+  end
+
+end

--- a/app/views/report/_table_alt_dpps.html.slim
+++ b/app/views/report/_table_alt_dpps.html.slim
@@ -1,0 +1,70 @@
+- raw_totals = local_assigns[:totals] || @alt_summary_totals
+- round      = local_assigns[:rounded] || false
+- year       = local_assigns[:year] || @year
+- level      = local_assigns[:level]
+
+- if raw_totals.count == 0
+  h2 No estimates were available for #{level} in #{year}
+- else
+  h2 style=('margin-top:20px') = "Summary Totals for #{level}"
+
+  - area_total = {}
+  - @alt_areas.each { |row| area_total[row['category']] = row }
+  - area_candidate = @alt_areas.first
+
+  - table_totals = {}
+  - data_columns = ['ESTIMATE', 'CONFIDENCE', 'GUESS_MIN', 'GUESS_MAX']
+
+  - merged_categories = ['F', 'G']
+
+  - totals = {}
+  - raw_totals.each do |row|
+    - if merged_categories.include?(row['CATEGORY'])
+      - totals[row['CATEGORY']] = row unless row['GUESS_MIN'].blank?
+    - else
+      - totals[row['CATEGORY']] = row
+
+  table.table style='font-size:16px'
+    tr
+      th
+      th colspan='2' Estimates from Surveys
+      th colspan='2' Guesses
+      th % range of known and possible 
+      th area (km<sup>2</sup>)
+    tr
+      th Survey category
+      th Estimate
+      th &plusmn; 95% CL
+      th From
+      th To
+      th
+      th
+
+    - keys = totals.keys
+    - merged_keys = keys.select { |key| merged_categories.include?(key) }
+    - keys.each_with_index do |category, index|
+      - row = totals[category]
+      tr
+        td = row['SURVEYTYPE']
+        - data_columns.each do |column|
+          td = add_and_display row, column, table_totals, column.eql?('CONFIDENCE') ? false : round
+        - unless merged_categories.include?(row['CATEGORY'])
+          td rowspan=(merged_categories.include?(keys[index+1] || nil) ? merged_keys.count + 1 : 1)
+            = add_and_display_area area_total[row['CATEGORY']], 'CATEGORY_RANGE_ASSESSED', table_totals
+        td = (round_area(area_total[row['CATEGORY']]['AREA']) || 0) unless merged_categories.include?(row['CATEGORY'])
+
+    tr
+      td Unassessed Range
+      td = unused_cell
+      td = unused_cell
+      td = unused_cell
+      td = unused_cell
+      td = round_area 100 - (table_totals['CATEGORY_RANGE_ASSESSED'] || 0)  
+    tr
+      td = 'Total'
+      - data_columns.each do |column|
+        td = number_with_delimiter(round ? rounded(table_totals[column].to_i) : table_totals[column].to_i)
+      td 100
+      td = round_area area_candidate['range_area']
+
+

--- a/app/views/report/preview_region.html.slim
+++ b/app/views/report/preview_region.html.slim
@@ -20,7 +20,19 @@
 
     == narrative
 
-    = render 'table_preview_summary_totals', level: @region, totals: @summary_totals_by_region, baselines: @baseline_total
+    div style='margin-top: 20px'
+      ul.nav.nav-tabs role='tablist'
+        li.active = link_to 'DPPS Calculations', '#dpps', 'aria-controls': 'dpps', role: 'tab', 'data-toggle': 'tab'
+        li = link_to 'Alternate, No Rounding', '#altdpps', 'aria-controls': 'altdpps', role: 'tab', 'data-toggle': 'tab'
+        li = link_to 'Alternate, Rounded', '#altdppsrounded', 'aria-controls': 'altdppsrounded', role: 'tab', 'data-toggle': 'tab'
+
+      .tab-content
+        .tab-pane.active#dpps role='tabpanel'
+          = render 'table_preview_summary_totals', level: @region, totals: @summary_totals_by_region, baselines: @baseline_total
+        .tab-pane#altdpps role='tabpanel'
+          = render 'table_alt_dpps', level: @region, totals: @alt_summary_totals
+        .tab-pane#altdppsrounded role='tabpanel'
+          = render 'table_alt_dpps', level: @region, totals: @alt_summary_totals, rounded: true
 
     - if current_user and current_user.admin?
       = render 'table_causes_of_change', totals: @causes_of_change_by_region_u, sums: @causes_of_change_sums_by_region_u

--- a/app/views/spreadsheets/index.html.slim
+++ b/app/views/spreadsheets/index.html.slim
@@ -1,0 +1,26 @@
+.row
+  .col-xs-12
+    h1 Spreadsheet Verification
+
+    h2 Upload a new spreadsheet
+    p.lead
+      ' Upload a new spreadsheet
+      - if @sheets.any?
+        ' or replace an existing spreadsheet
+      | to review.
+    = form_tag spreadsheets_path, { :multipart => true } do
+      div = file_field_tag 'file'
+      div = submit_tag
+
+    - if @sheets.any?
+      h2 Review an existing spreadsheet
+      table.table
+        thead
+          tr
+            th Name
+            th Upload Date
+        tbody
+          - @sheets.each do |sheet|
+            tr
+              td = link_to sheet[:name], spreadsheet_path(sheet[:name])
+              td = sheet[:created_at]

--- a/app/views/spreadsheets/show.html.slim
+++ b/app/views/spreadsheets/show.html.slim
@@ -1,0 +1,56 @@
+.row
+  .col-xs-12
+    h1 Spreadsheet Verification Results
+
+    - @sheets.each do |result|
+      - sheet  = result[:sheet]
+      - errors = []
+      h2 = result[:name]
+      h3 Expected Results:
+      table.table
+        tr
+          th Survey category
+          th Estimate
+          th &plusmn; 95% CL
+          th From
+          th To
+          th Range
+        - result[:expected].each do |category, row|
+          tr
+            - row.each do |key, value|
+              - if key == 'CATEGORY' || key == 'RANGE'
+                td = value
+              - elsif value.blank? || value == '--'
+                td = value
+              - else
+                - expected = value.to_i rescue nil
+                - actual   = result[:actual][category][key].to_i rescue nil
+                - if expected.nil?
+                  td = value
+                - elsif expected == actual
+                  td.success = value
+                - else
+                  td.danger = value
+                  - errors << { category: row['CATEGORY'], key: key, expected: expected, actual: actual }
+      - if errors.any?
+        p.text-danger 
+          i.glyphicon.glyphicon-remove-sign
+          '
+          | The following columns did not match as expected:
+        table.table
+          tr
+            td Category
+            td Column
+            td Expected Value
+            td Computed Value
+          - errors.each do |error|
+            tr
+              td = error[:category]
+              td = error[:key]
+              td = error[:expected]
+              td = error[:actual]
+      - else
+        p.text-success
+          i.glyphicon.glyphicon-ok-sign
+          '
+          | No errors were found in calculations.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,6 +66,8 @@ Aaed::Application.routes.draw do
 
   resources :data_request_forms
 
+  resources :spreadsheets, only: [:index, :create, :show]
+
   get 'about' => 'about#index'
   get 'about/darp' => 'about#darp'
 


### PR DESCRIPTION
This PR achieves the same thing as the previous one, but also includes a commit to display the DPPS summary table alongside the new calculation methods with and without rounding.  This is only available on the 2013 preview report on the region pages, as a proof of concept, but can be scaled to all pages once we finalize it.

You can safely merge the other PR without affecting reports.  Or, you can immediately change the reports by merging this PR.