### PR TITLE
Correct validation errors for hidden fields.

### DIFF
--- a/app/controllers/report_narratives_controller.rb
+++ b/app/controllers/report_narratives_controller.rb
@@ -29,6 +29,7 @@ class ReportNarrativesController < ApplicationController
   # GET /report_narratives/new.json
   def new
     @report_narrative = ReportNarrative.new
+    @report_narrative.uri = params[:uri]
 
     respond_to do |format|
       format.html # new.html.erb

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -37,11 +37,12 @@ class Submission < ActiveRecord::Base
 
   class SubmissionValidator < ActiveModel::Validator
     def validate(record)
-      if record.phenotype == "" and record.species.scientific_name == "Loxodonta africana"
-        record.errors[:phenotype] << "must be answered if you are reporting on Loxodonta africana"
-      end
-      if record.phenotype_basis == "" and record.phenotype != "Unknown" and record.species.scientific_name == "Loxodonta africana"
-        record.errors[:phenotype_basis] << "must be answered if you are reporting on Loxodonta africana"
+      if !record.species.nil? && record.species.scientific_name == "Loxodonta africana"
+        if record.phenotype.blank?
+          record.errors[:phenotype] << "must be answered if you are reporting on Loxodonta africana"
+        elsif record.phenotype_basis.blank? && record.phenotype != 'Unknown'
+          record.errors[:phenotype_basis] << "must be answered if you are reporting on Loxodonta africana"
+        end
       end
       if record.right_to_grant_permission.nil?
         record.errors[:right_to_grant_permission] << "can't be blank"

--- a/app/views/layouts/count_crud_form.html.slim
+++ b/app/views/layouts/count_crud_form.html.slim
@@ -6,7 +6,7 @@
     = semantic_form_for @level do |f|
       = render "shared/error_messages", :target => @level
       = f.inputs do
-        = f.input :population_submission_id, :as => :hidden, :value => @population_submission.id
+        = f.input :population_submission_id, :as => :hidden, :input_html => { :value => @population_submission.id }
         = f.input :surveyed_at_stratum_level, :as => :radio
         = f.input :stratum_level_data_submitted, :as => :radio
       = f.actions

--- a/app/views/population_submission_attachments/_form.html.slim
+++ b/app/views/population_submission_attachments/_form.html.slim
@@ -15,7 +15,7 @@
       | Embargoed until #{@population_submission.embargo_date}
   .file_uploader
     = f.inputs do
-      = f.input :population_submission_id, :as => :hidden, :value => @population_submission.id
+      = f.input :population_submission_id, :as => :hidden, :input_html => { :value => @population_submission.id }
       = f.input :attachment_type, :as => :select, :collection => ['Survey report','Survey Shapefile','Range Shapefile','Other']
       .submit_confirmation
         | You can supply restricted attachments that will not be shared on this site under the general

--- a/app/views/population_submissions/_form.html.slim
+++ b/app/views/population_submissions/_form.html.slim
@@ -3,7 +3,7 @@
 = semantic_form_for @population_submission do |f|
   = render "shared/error_messages", :target => @population_submission
   = f.inputs do
-    = f.input :submission_id, :as => :hidden, :value => @submission.id
+    = f.input :submission_id, :as => :hidden, :input_html => { :value => @submission.id }
     = f.input :data_licensing, :as => :radio, :collection => {raw(t("creative_commons")) => "CC", raw(t("embargoed_until")) => "CC/EM", raw(t("controlled_redistribution")) => "CR"}
     = f.input :embargo_date, :required => true, :as => :date
     = f.input :site_name

--- a/app/views/report_narratives/new.html.slim
+++ b/app/views/report_narratives/new.html.slim
@@ -4,7 +4,7 @@
     p= link_to t('back'), report_narratives_path
     = semantic_form_for @report_narrative do |f|
       = f.inputs do
-        = f.input :uri, :as => 'hidden', :value => params[:uri]
+        = f.input :uri, :as => 'hidden'
         = f.input :narrative
         = f.input :footnote
 

--- a/app/views/submissions/_form.html.slim
+++ b/app/views/submissions/_form.html.slim
@@ -9,7 +9,7 @@
         = f.input :country, :as => :select, :collection => @submission.range_states
         = f.input :phenotype, :as => :select, :collection => ["Savanna", "Forest", "Both", "Unknown"]
         = f.input :phenotype_basis, :as => :select, :collection => ["Genetic evidence gathered on-site", "Appearance of elephants", "Geographical location", "Habitat"]
-        = f.input :data_type, :as => :hidden, :value => 'Population estimate'
+        = f.input :data_type, :as => :hidden, :input_html => { :value => 'Population estimate' }
         = f.input :right_to_grant_permission, :required => true, :as => :radio, :collection => {"Yes, I have the right to grant permission to IUCN to use the data as specified" => true, "No, I do not have the right to grant permission, please email the following person:" => false}
         = f.input :permission_email, :as => :email
       = f.actions

--- a/app/views/survey_aerial_sample_count_strata/_form.html.slim
+++ b/app/views/survey_aerial_sample_count_strata/_form.html.slim
@@ -3,7 +3,7 @@
 = semantic_form_for @survey_aerial_sample_count_stratum do |f|
   = render "shared/error_messages", :target => @survey_aerial_sample_count_stratum
   = f.inputs do
-    = f.input :survey_aerial_sample_count_id, :as => :hidden, :value => @level.parent_count.id
+    = f.input :survey_aerial_sample_count_id, :as => :hidden, :input_html => { :value => @level.parent_count.id }
     = f.input :stratum_name
     = f.input :stratum_area
     = f.input :population_estimate

--- a/app/views/survey_aerial_sample_counts/_form.html.slim
+++ b/app/views/survey_aerial_sample_counts/_form.html.slim
@@ -3,7 +3,7 @@
 = semantic_form_for @survey_aerial_sample_count do |f|
   = render "shared/error_messages", :target => @survey_aerial_sample_count
   = f.inputs do
-    = f.input :population_submission_id, :as => :hidden, :value => @population_submission.id
+    = f.input :population_submission_id, :as => :hidden, :input_html => { :value => @population_submission.id }
     = f.input :total_possible_transects
     = f.input :surveyed_at_stratum_level, :as => :radio
     = f.input :stratum_level_data_submitted, :as => :radio

--- a/app/views/survey_aerial_total_count_strata/_form.html.slim
+++ b/app/views/survey_aerial_total_count_strata/_form.html.slim
@@ -3,7 +3,7 @@
 = semantic_form_for @survey_aerial_total_count_stratum do |f|
   = render "shared/error_messages", :target => @survey_aerial_total_count_stratum
   = f.inputs do
-    = f.input :survey_aerial_total_count_id, :as => :hidden, :value => @level.parent_count.id
+    = f.input :survey_aerial_total_count_id, :as => :hidden, :input_html => { :value => @level.parent_count.id }
     = f.input :stratum_name
     = f.input :stratum_area
     = f.input :population_estimate

--- a/app/views/survey_aerial_total_counts/_form.html.slim
+++ b/app/views/survey_aerial_total_counts/_form.html.slim
@@ -3,7 +3,7 @@
 = semantic_form_for @survey_aerial_total_count do |f|
   = render "shared/error_messages", :target => @survey_aerial_total_count
   = f.inputs do
-    = f.input :population_submission_id, :as => :hidden, :value => @population_submission.id
+    = f.input :population_submission_id, :as => :hidden, :input_html => { :value => @population_submission.id }
     = f.input :surveyed_at_stratum_level, :as => :radio
     = f.input :stratum_level_data_submitted, :as => :radio
   = f.actions

--- a/app/views/survey_dung_count_line_transect_strata/_form.html.slim
+++ b/app/views/survey_dung_count_line_transect_strata/_form.html.slim
@@ -3,7 +3,7 @@
 = semantic_form_for @survey_dung_count_line_transect_stratum do |f|
   = render "shared/error_messages", :target => @survey_dung_count_line_transect_stratum
   = f.inputs do
-    = f.input :survey_dung_count_line_transect_id, :as => :hidden, :value => @level.parent_count.id
+    = f.input :survey_dung_count_line_transect_id, :as => :hidden, :input_html => { :value => @level.parent_count.id }
     = f.input :stratum_name
     = f.input :stratum_area
     = f.input :population_estimate

--- a/app/views/survey_faecal_dna_strata/_form.html.slim
+++ b/app/views/survey_faecal_dna_strata/_form.html.slim
@@ -3,7 +3,7 @@
 = semantic_form_for @survey_faecal_dna_stratum do |f|
   = render "shared/error_messages", :target => @survey_faecal_dna_stratum
   = f.inputs do
-    = f.input :survey_faecal_dna_id, :as => :hidden, :value => @level.parent_count.id
+    = f.input :survey_faecal_dna_id, :as => :hidden, :input_html => { :value => @level.parent_count.id }
     = f.input :stratum_name
     = f.input :stratum_area
     = f.input :population_estimate

--- a/app/views/survey_ground_sample_count_strata/_form.html.slim
+++ b/app/views/survey_ground_sample_count_strata/_form.html.slim
@@ -3,7 +3,7 @@
 = semantic_form_for @survey_ground_sample_count_stratum do |f|
   = render "shared/error_messages", :target => @survey_ground_sample_count_stratum
   = f.inputs do
-    = f.input :survey_ground_sample_count_id, :as => :hidden, :value => @level.parent_count.id
+    = f.input :survey_ground_sample_count_id, :as => :hidden, :input_html => { :value => @level.parent_count.id }
     = f.input :stratum_name
     = f.input :stratum_area
     = f.input :population_estimate

--- a/app/views/survey_ground_total_count_strata/_form.html.slim
+++ b/app/views/survey_ground_total_count_strata/_form.html.slim
@@ -3,7 +3,7 @@
 = semantic_form_for @survey_ground_total_count_stratum do |f|
   = render "shared/error_messages", :target => @survey_ground_total_count_stratum
   = f.inputs do
-    = f.input :survey_ground_total_count_id, :as => :hidden, :value => @level.parent_count.id
+    = f.input :survey_ground_total_count_id, :as => :hidden, :input_html => { :value => @level.parent_count.id }
     = f.input :stratum_name
     = f.input :stratum_area
     = f.input :population_estimate

--- a/app/views/survey_individual_registrations/_form.html.slim
+++ b/app/views/survey_individual_registrations/_form.html.slim
@@ -3,7 +3,7 @@
 = semantic_form_for @survey_individual_registration do |f|
   = render "shared/error_messages", :target => @survey_individual_registration
   = f.inputs do
-    = f.input :population_submission_id, :as => :hidden, :value => @population_submission.id
+    = f.input :population_submission_id, :as => :hidden, :input_html => { :value => @population_submission.id }
     = f.input :population_estimate
     = f.input :population_upper_range
     = f.input :monitoring_years, :as => :select, :collection => Time.now.year.downto(1950)

--- a/app/views/survey_others/_form.html.slim
+++ b/app/views/survey_others/_form.html.slim
@@ -3,7 +3,7 @@
 = semantic_form_for @survey_other do |f|
   = render "shared/error_messages", :target => @survey_other
   = f.inputs do
-    = f.input :population_submission_id, :as => :hidden, :value => @population_submission.id
+    = f.input :population_submission_id, :as => :hidden, :input_html => { :value => @population_submission.id }
     = f.input :other_method_description
     = f.input :population_estimate_min
     = f.input :population_estimate_max


### PR DESCRIPTION
Fields that are hidden now have their values set
using the input_html hash instead of being directly
set.  I believe this is a library API change.

See #371