### PR TITLE
Restore javascript toggle of survey zones.

### DIFF
--- a/app/views/report/preview_country.html.slim
+++ b/app/views/report/preview_country.html.slim
@@ -111,6 +111,7 @@
           tr
             td
               a href="javascript:toggle_section('#{@rn.gsub(/[^\w\d]/,'')}')" style='text-decoration:none'  +
+              '
               = @rn
             td= @cc
             td= @ty
@@ -127,11 +128,10 @@
             td style="text-align:center" = @lo
             td style="text-align:center" = @la
           - group.each do |row|
-            tr style=('height:18px; display:none')
-              td
-                | &#160;
-                | &#160;
-                a href="/population_submissions/#{row['population_submission_id']}" != row['stratum_name']
+            tr data-section=("#{@rn.gsub(/[^\w\d]/,'')}") style=('height:18px; display:none')
+              td 
+                div style='margin-left:20px;'
+                  a href="/population_submissions/#{row['population_submission_id']}" = row['stratum_name']
               td= row['ReasonForChange']
               td= row['method_and_quality'].gsub(/[\d]/,'')
               td style="text-align:center" = row['CATEGORY']

--- a/app/views/report/preview_site.html.slim
+++ b/app/views/report/preview_site.html.slim
@@ -85,7 +85,7 @@
         - @elephant_estimates_by_site.each do |row|
           tr style='height:18px' 
             td
-              a href="/population_submissions/#{row['population_submission_id']}" != row['survey_zone']
+              a href="/population_submissions/#{row['population_submission_id']}" = row['survey_zone']
             td= row['ReasonForChange']
             td= row['method_and_quality'].gsub(/[\d]/,'')
             td style="text-align:center" = row['CATEGORY']


### PR DESCRIPTION
Some important data tags must have went missing in
transport.  Restore the proper attributes so things
expand as advertised.

Also, related, fixed an issue in the country/site
reports where an improper assignment operator was
being used.  Old template style, conversions didn't
pick it up.