### PR TITLE
New viewer for stratum data

### DIFF
--- a/app/controllers/survey_geometries_controller.rb
+++ b/app/controllers/survey_geometries_controller.rb
@@ -1,0 +1,9 @@
+class SurveyGeometriesController < ApplicationController
+
+  def geojson_map
+    @survey_geometry = SurveyGeometry.find(params[:id])
+    feature = RGeo::GeoJSON.encode(@survey_geometry.geom)
+    render :json => feature
+  end
+
+end

--- a/app/views/application/_map_stratum.html.slim
+++ b/app/views/application/_map_stratum.html.slim
@@ -1,0 +1,18 @@
+= map container_id: "leaflet_map", center: {latlng: [-12.04, 18.59], zoom: 4}
+javascript:
+  var survey_map = new L.geoJson();
+  //addition of scale
+  L.control.scale({position:'bottomleft', metric:true, imperial:false }).addTo(map);
+  function onEachFeature(feature, layer) {
+    var popupContent = "<table>"
+    for (var key in feature.properties) {
+      popupContent += "<tr><th>"+key+"</th><td>"+feature.properties[key]+"<td></tr>"
+    }
+    popupContent += "</table>"
+    layer.bindPopup(popupContent);
+  }
+  $.getJSON("/survey_geometry/#{level.survey_geometry_id}/map", function(data) {
+    var survey_map = L.geoJson(data, {onEachFeature: onEachFeature});
+    survey_map.addTo(map);
+    map.fitBounds(survey_map.getBounds());
+  });

--- a/app/views/survey_aerial_sample_count_strata/show.html.slim
+++ b/app/views/survey_aerial_sample_count_strata/show.html.slim
@@ -65,5 +65,4 @@
     .show_stratum
       == best_label_for 'carcasses_very_old'
       = @level.carcasses_very_old
-    == map_stratum @level
-
+    = render :partial => "map_stratum", :locals => { :level => @level }

--- a/app/views/survey_aerial_total_count_strata/show.html.slim
+++ b/app/views/survey_aerial_total_count_strata/show.html.slim
@@ -44,5 +44,4 @@
     .show_stratum
       == best_label_for 'carcasses_very_old'
       = @level.carcasses_very_old
-    == map_stratum @level
-
+    = render :partial => "map_stratum", :locals => { :level => @level }

--- a/app/views/survey_dung_count_line_transect_strata/show.html.slim
+++ b/app/views/survey_dung_count_line_transect_strata/show.html.slim
@@ -179,4 +179,4 @@
     .show_stratum
       == best_label_for 'dung_encounter_rate'
       = @level.dung_encounter_rate
-    == map_stratum @level
+    = render :partial => "map_stratum", :locals => { :level => @level }

--- a/app/views/survey_faecal_dna_strata/show.html.slim
+++ b/app/views/survey_faecal_dna_strata/show.html.slim
@@ -56,5 +56,4 @@
     .show_stratum
       == best_label_for 'sampling_locations'
       = @level.sampling_locations
-    == map_stratum @level
-
+    = render :partial => "map_stratum", :locals => { :level => @level }

--- a/app/views/survey_ground_sample_count_strata/show.html.slim
+++ b/app/views/survey_ground_sample_count_strata/show.html.slim
@@ -50,5 +50,4 @@
     .show_stratum
       == best_label_for 'person_hours'
       = @level.person_hours
-    == map_stratum @level
-
+    = render :partial => "map_stratum", :locals => { :level => @level }

--- a/app/views/survey_ground_total_count_strata/show.html.slim
+++ b/app/views/survey_ground_total_count_strata/show.html.slim
@@ -35,5 +35,4 @@
     .show_stratum
       == best_label_for 'actually_seen'
       = @level.actually_seen
-    == map_stratum @level
-
+    = render :partial => "map_stratum", :locals => { :level => @level }

--- a/app/views/survey_individual_registrations/show.html.slim
+++ b/app/views/survey_individual_registrations/show.html.slim
@@ -18,4 +18,4 @@
     .show_stratum
       == best_label_for 'porous_fenced_site'
       = @level.porous_fenced_site
-    == map_stratum @level
+    = render :partial => "map_stratum", :locals => { :level => @level }

--- a/app/views/survey_others/show.html.slim
+++ b/app/views/survey_others/show.html.slim
@@ -15,5 +15,4 @@
     .show_stratum
       == best_label_for 'population_estimate_max'
       = @level.population_estimate_max
-    == map_stratum @level
-
+    = render :partial => "map_stratum", :locals => { :level => @level }

--- a/config/application.rb
+++ b/config/application.rb
@@ -54,7 +54,7 @@ module Aaed
     # Settings for static assets
     config.static_cache_control = "public, max-age=3600"
 
-    # Mail settings 
+    # Mail settings
     config.action_mailer.default_url_options = { :host => "www.elephantdatabase.org" }
 
     my_date_formats = { :default => '%d/%m/%Y' }
@@ -62,5 +62,8 @@ module Aaed
     Date::DATE_FORMATS.merge!(my_date_formats)
 
     config.assets.initialize_on_precompile = false
+
+    # import future
+    config.active_record.raise_in_transactional_callbacks = true
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,6 +62,7 @@ Aaed::Application.routes.draw do
 
   get 'population_submission_attachments/download/:id' => 'population_submission_attachments#download'
   get 'population_submissions/:id/map' => 'population_submissions#geojson_map'
+  get 'survey_geometry/:id/map' => 'survey_geometries#geojson_map'
 
   get 'data_request_forms/thanks' => 'data_request_forms#thanks'
 

--- a/db/migrate/20151124062712_add_survey_geom.rb
+++ b/db/migrate/20151124062712_add_survey_geom.rb
@@ -1,0 +1,5 @@
+class AddSurveyGeom < ActiveRecord::Migration
+  def change
+    add_column :survey_geometries, :geom, :geometry
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151124041257) do
+ActiveRecord::Schema.define(version: 20151124062712) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -793,6 +793,7 @@ ActiveRecord::Schema.define(version: 20151124041257) do
 
   create_table "survey_geometries", force: :cascade do |t|
     t.geometry "geometry", limit: {:srid=>0, :type=>"geometry"}
+    t.geometry "geom",     limit: {:srid=>0, :type=>"geometry"}
   end
 
   create_table "survey_geometry_locator_buffered", id: false, force: :cascade do |t|


### PR DESCRIPTION
This is built on the rgeo, leaflet, geojson stack and discards the
old Google Maps function with hand-built polygons. Accordingly,
this now correctly previews multipolygons which clears the
longstanding issue #331.

rgeo has trouble with a geometry column named 'geometry' due to a
name conflict; also the existing survey_geometry.geometry column
had a mix of 2d/3d and different SRID data in it. A migration here
creates a new 'geom' column but doesn't do anything to populate or
use it higher in the stack.

For now, a manual query is necessary to migrate old data into this
column:

update survey_geometries set geom=ST_Force2D(geometry);

This will be added to a migration later that is capable of also
updating the rest of the view stack to track this change.

Fix #331