### PR TITLE
Remove modeled extrapolations from D calcs.

### DIFF
--- a/app/helpers/alt_dpps_helper.rb
+++ b/app/helpers/alt_dpps_helper.rb
@@ -166,6 +166,7 @@ module AltDppsHelper
         #{analysis_name}
         AND e.category = 'D'
         AND #{scope}
+        AND e.site_name <> 'Rest of Gabon'
       GROUP BY "CATEGORY", "SURVEYTYPE"
 
       UNION


### PR DESCRIPTION
In ADD calculation, ensure that the modeled extrapolations,
in this case, Rest of Gabon, are not included in the sums,
as they are already accounted for in another category.

See #383