### PR TITLE
Country level mapping

### DIFF
--- a/app/assets/javascripts/country-map.coffee
+++ b/app/assets/javascripts/country-map.coffee
@@ -1,0 +1,69 @@
+map = null
+MAP_INITIALIZED = false
+COUNTRY_LAYER = null
+
+strip_for = (map_props) ->
+  html = "<div>#{map_props.aed_year} #{map_props.aed_name}</div>"
+  html += "<div style='font-size: x-small'>#{map_props.aed_citation}</div>"
+  html += "<div style='font-size: x-small'><a href='#{map_props.uri}' target='_blank'>#{map_props.aed_stratum}</a> est. #{map_props.aed_estimate}, #{map_props.aed_area} km²</div>"
+
+style = (feature) ->
+  return {
+    color: "#007700"
+    weight: 1
+    opacity: 1
+    fillColor: "#77ff77"
+    fillOpacity: 0.4
+  }
+
+onEachFeature = (feature, layer) ->
+  popupContent = strip_for feature.properties
+  layer.bindPopup popupContent
+
+initialize_map = (map_uri)->
+
+  console.log "Initializing map with #{map_uri}"
+
+  # This work duplicates the map helper used elsewhere, but
+  # in this case we need to do it in a deferred fashion so the
+  # map helper won't get it done for us.
+  map = L.map('CM_map')
+
+  map.setView([-12.04, 18.59], 4)
+  L.tileLayer('http://otile2.mqcdn.com/tiles/1.0.0/osm/{z}/{x}/{y}.png', {
+            attribution: 'AfESG',
+            maxZoom: 18,
+  subdomains: '',
+  }).addTo(map)
+
+  survey_map = new L.geoJson()
+  L.control.scale(
+    position: "bottomleft"
+    metric: true
+    imperial: false
+  ).addTo map
+
+  $.getJSON "/country/survey_map/" + map_uri + "/", (data) ->
+    if COUNTRY_LAYER
+      map.removeLayer COUNTRY_LAYER
+    COUNTRY_LAYER = L.geoJson(data,
+      style: style
+      onEachFeature: onEachFeature
+    )
+    COUNTRY_LAYER.addTo map
+    map.fitBounds COUNTRY_LAYER.getBounds()
+
+  MAP_INITIALIZED = true
+
+window.load_country_map = (map_uri) ->
+  initialize_map(map_uri) unless MAP_INITIALIZED
+
+$ ->
+  $(".CM_context").each ->
+    target = $(this).data('target')
+    map_uri = $(this).data('mapuri')
+    $("a[href=\"#{target}\"]").on 'shown.bs.tab', ->
+      $('.below_tabs').hide()
+      load_country_map(map_uri)
+    $("a[href=\"#{target}\"]").on 'hidden.bs.tab', ->
+      $('.below_tabs').show()

--- a/app/assets/stylesheets/country-map.scss
+++ b/app/assets/stylesheets/country-map.scss
@@ -1,0 +1,3 @@
+#CM_map {
+  height: 400px;
+}

--- a/app/controllers/countries_controller.rb
+++ b/app/controllers/countries_controller.rb
@@ -45,4 +45,40 @@ class CountriesController < ApplicationController
     }
     render :json => feature_collection
   end
+
+  def geojson_map_public
+    analysis = Analysis.where(analysis_name: params[:analysis]).first
+    year = params[:year].to_i
+    features = []
+    analysis.input_zones.where(country: params[:iso_code]).each do |input_zone|
+      strata = []
+      if analysis.comparison_year == year
+        strata = input_zone.fetch_replaced_strata
+      elsif analysis.analysis_year == year
+        strata = input_zone.fetch_new_strata
+      end
+      strata.each do |stratum|
+        if stratum.survey_geometry
+          population_submission = stratum.parent_count.population_submission
+          feature = RGeo::GeoJSON.encode(stratum.survey_geometry.geom)
+          feature['properties'] = {
+            'aed_stratum' => "#{population_submission.survey_type}#{stratum.id}",
+            'uri' => "/#{stratum.class.name.pluralize.underscore}/#{stratum.id}",
+            'aed_name' => stratum.stratum_name,
+            'aed_year' => population_submission.completion_year,
+            'aed_citation' => population_submission.short_citation,
+            'aed_area' => stratum.stratum_area,
+            'aed_estimate' => stratum.population_estimate
+          }
+          features << feature
+        end
+      end
+    end
+    feature_collection = {
+      'type' => 'FeatureCollection',
+      'features' => features
+    }
+    render :json => feature_collection
+  end
+
 end

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -514,6 +514,7 @@ class ReportController < ApplicationController
     @continent = params[:continent]
     @region = params[:region].gsub('_',' ')
     @country = params[:country].gsub('_',' ')
+    @map_uri = Country.where(name: params[:country]).first().iso_code + "/" + params[:filter] + "/" + params[:year]
     @filter = params[:filter]
     @preview_title = official_title(@filter) or @filter.humanize.upcase
 

--- a/app/models/change.rb
+++ b/app/models/change.rb
@@ -17,4 +17,39 @@ class Change < ActiveRecord::Base
     :comments
   )
 
+  def fetch_strata(s)
+    mappings={
+      'AS' => 'SurveyAerialSampleCountStratum',
+      'AT' => 'SurveyAerialTotalCountStratum',
+      'DC' => 'SurveyDungCountLineTransectStratum',
+      'GD' => 'SurveyFaecalDnaStratum',
+      'GS' => 'SurveyGroundSampleCountStratum',
+      'GT' => 'SurveyGroundTotalCountStrata',
+      'IR' => 'SurveyIndividualRegistrations',
+      'O' => 'SurveyOthers'
+    }
+    strata_codes = s.split(/,\s*/)
+    result_strata = []
+    strata_codes.each do |code|
+      stratum_type = code.gsub(/\d/,'')
+      puts stratum_type
+      stratum_id = code.gsub(/\D/,'').to_i
+      puts stratum_id
+      begin
+        result_strata << eval(mappings[stratum_type]).find(stratum_id)
+      rescue Exception => e
+        puts e.inspect
+      end
+    end
+    return result_strata
+  end
+
+  def fetch_replaced_strata
+    fetch_strata replaced_strata
+  end
+
+  def fetch_new_strata
+    fetch_strata new_strata
+  end
+
 end

--- a/app/views/application/_tabs.html.slim
+++ b/app/views/application/_tabs.html.slim
@@ -17,4 +17,4 @@
       .tab-content
         - tabs.each_with_index do |tab, index|
           .tab-pane id=("#{id}-page-#{index}") class=(index == 0 ? 'active' : nil) role='tabpanel'
-            = render tab[:template], (tab[:args] || {})
+            = render tab[:template], (tab[:args] || {}).merge({target:"##{id}-page-#{index}"})

--- a/app/views/report/_map.html.slim
+++ b/app/views/report/_map.html.slim
@@ -1,0 +1,3 @@
+#CM_map
+
+.CM_context data-target=local_assigns[:target] data-mapuri=local_assigns[:map_uri]

--- a/app/views/report/preview_country.html.slim
+++ b/app/views/report/preview_country.html.slim
@@ -22,146 +22,148 @@
     == narrative
 
     = render 'tabs', tabs: [ { title: 'DPPS Calculations', template: 'table_preview_summary_totals', args: { level: @country, totals: @summary_totals_by_country, baselines: @baseline_total } },
-      { admin: true, title: 'Alternate, No Rounding', template: 'table_alt_dpps', args: { level: @country, totals: @alt_summary_totals } } ]
+      { admin: true, title: 'Alternate, No Rounding', template: 'table_alt_dpps', args: { level: @country, totals: @alt_summary_totals } },
+      { admin: true, title: 'Map', template: 'map', args: { country: @country, map_uri: @map_uri } } ]
 
-    - if current_user and current_user.admin?
-      = render 'table_causes_of_change', totals: @causes_of_change_by_country_u, sums: @causes_of_change_sums_by_country_u
-      = render 'table_causes_of_change', totals: @causes_of_change_by_country, sums: @causes_of_change_sums_by_country,
-        hideable: true,
-        title: 'Interpretation of Changes in Estimates from Previous Report (2007 scaling)'
+    .below_tabs
+      - if current_user and current_user.admin?
+        = render 'table_causes_of_change', totals: @causes_of_change_by_country_u, sums: @causes_of_change_sums_by_country_u
+        = render 'table_causes_of_change', totals: @causes_of_change_by_country, sums: @causes_of_change_sums_by_country,
+          hideable: true,
+          title: 'Interpretation of Changes in Estimates from Previous Report (2007 scaling)'
 
-      .toggle style=('margin-top:-20px; margin-bottom: 10px; text-align: right')
-        a onclick='toggle_hideables()'  toggle scaling
+        .toggle style=('margin-top:-20px; margin-bottom: 10px; text-align: right')
+          a onclick='toggle_hideables()'  toggle scaling
 
-    = render 'table_area_of_range_covered', totals: @area_of_range_covered_by_country, sums: @area_of_range_covered_sum_by_country
+      = render 'table_area_of_range_covered', totals: @area_of_range_covered_by_country, sums: @area_of_range_covered_sum_by_country
 
-    - if @elephant_estimates_by_country.num_tuples > 0
-      h2
-        = @country
-        |: Elephant Estimates
-      table.table
-        tr
-          th style="border:none"
-            th style="border:none"  Cause of
-          th colspan=3 style="text-align:center"
-            | Survey Details
-            sup 2
-          th colspan=2 style="text-align:center"  Number of Elephants
-          th style="border:none"
-          th style="border:none"
-          th.numeric style=("border:none; padding-right:10px")  Area
-          th colspan=2 style="text-align:center"  Map Location
-        tr
-          th Input Zone
-          th
-            | Change
-            sup 1
-          th Type
-          th Reliab.
-          th Year
-          th.numeric Estimate
-          th.numeric 95% C.L.
-          th style="padding-left:10px"  Source
-          th
-            | PFS
-            sup 3
-          th.numeric style="padding-right:10px"  (km²)
-          th style='text-align:center'  Lon.
-          th style='text-align:center'  Lat.
-        - @elephant_estimate_groups.each do |group|
-          - @rn = @cc = @ty = @yr = @re = ''
-          - @ar = @n = @pv = @es = @cl = @car = @dp = @dpps = @ra = 0
-          - if group.size > 1
-            - group.each do |row|
-              - @rn = row['replacement_name']
-              - @cc = row['ReasonForChange']
-              - @ca = row['CATEGORY']
-              - @ty = row['method_and_quality'].gsub(/[\d]/,'')
-              - @yr = row['CYEAR']
-              - @re = row['REFERENCE']
-              - @dp = @dp + row['DP'].to_f
-              - @dpps = @dpps + row['DPPS'].to_f
-              - @car = @car + row['CALC_SQKM'].to_f
-              - @ar = @ar + row['AREA_SQKM'].to_i
-              - @pv = @pv + row['population_variance'].to_f
-              - @es = @es + row['ESTIMATE'].to_i
-              - @lo = row['LON']
-              - @la = row['LAT']
-              - @ra = row['RA'].to_f
-              - @n = @n + 1
-          - else
-            - group.each do |row|
-              - @rn = row['replacement_name']
-              - @cc = row['ReasonForChange']
-              - @ca = row['CATEGORY']
-              - @ty = row['method_and_quality'].gsub(/[\d]/,'')
-              - @yr = row['CYEAR']
-              - @re = row['REFERENCE']
-              - @dp = row['DP'].to_f
-              - @dpps = row['DPPS'].to_f
-              - @car = row['CALC_SQKM'].to_f
-              - @ar = row['AREA_SQKM']
-              - @pv = 0
-              - @cl = row['CL95']
-              - @es = row['ESTIMATE']
-              - @lo = row['LON']
-              - @la = row['LAT']
-              - @n = @n + 1
-              - @ra = row['RA'].to_f
-          - @pf = (Math.log10((((@dp+0.001)/(@dpps+0.001))+1)/(@car/@ra))).round rescue '?'
+      - if @elephant_estimates_by_country.num_tuples > 0
+        h2
+          = @country
+          |: Elephant Estimates
+        table.table
           tr
-            td
-              a href="javascript:toggle_section('#{@rn.gsub(/[^\w\d]/,'')}')" style='text-decoration:none'  +
-              '
-              = @rn
-            td= @cc
-            td= @ty
-            td style="text-align:center" = @ca
-            td= @yr
-            td style="text-align:right" = number_with_delimiter @es
-            -if @pv>0
-              td style="text-align:right" = number_with_delimiter ((Math.sqrt(@pv))*1.96).round
+            th style="border:none"
+              th style="border:none"  Cause of
+            th colspan=3 style="text-align:center"
+              | Survey Details
+              sup 2
+            th colspan=2 style="text-align:center"  Number of Elephants
+            th style="border:none"
+            th style="border:none"
+            th.numeric style=("border:none; padding-right:10px")  Area
+            th colspan=2 style="text-align:center"  Map Location
+          tr
+            th Input Zone
+            th
+              | Change
+              sup 1
+            th Type
+            th Reliab.
+            th Year
+            th.numeric Estimate
+            th.numeric 95% C.L.
+            th style="padding-left:10px"  Source
+            th
+              | PFS
+              sup 3
+            th.numeric style="padding-right:10px"  (km²)
+            th style='text-align:center'  Lon.
+            th style='text-align:center'  Lat.
+          - @elephant_estimate_groups.each do |group|
+            - @rn = @cc = @ty = @yr = @re = ''
+            - @ar = @n = @pv = @es = @cl = @car = @dp = @dpps = @ra = 0
+            - if group.size > 1
+              - group.each do |row|
+                - @rn = row['replacement_name']
+                - @cc = row['ReasonForChange']
+                - @ca = row['CATEGORY']
+                - @ty = row['method_and_quality'].gsub(/[\d]/,'')
+                - @yr = row['CYEAR']
+                - @re = row['REFERENCE']
+                - @dp = @dp + row['DP'].to_f
+                - @dpps = @dpps + row['DPPS'].to_f
+                - @car = @car + row['CALC_SQKM'].to_f
+                - @ar = @ar + row['AREA_SQKM'].to_i
+                - @pv = @pv + row['population_variance'].to_f
+                - @es = @es + row['ESTIMATE'].to_i
+                - @lo = row['LON']
+                - @la = row['LAT']
+                - @ra = row['RA'].to_f
+                - @n = @n + 1
             - else
-              td style="text-align:right" = @cl.to_s.gsub(/[^\d]/, "")!="0" ? number_with_delimiter(@cl) : ""
-            td style="padding-left:10px" = @re
-            td style="text-align:center" = @pf
-            td style="text-align:right" = @ar.to_s!="0" ? number_with_delimiter(@ar) : ""
-            td style="text-align:center" = @lo
-            td style="text-align:center" = @la
-          - group.each do |row|
-            tr data-section=("#{@rn.gsub(/[^\w\d]/,'')}") style=('height:18px; display:none')
+              - group.each do |row|
+                - @rn = row['replacement_name']
+                - @cc = row['ReasonForChange']
+                - @ca = row['CATEGORY']
+                - @ty = row['method_and_quality'].gsub(/[\d]/,'')
+                - @yr = row['CYEAR']
+                - @re = row['REFERENCE']
+                - @dp = row['DP'].to_f
+                - @dpps = row['DPPS'].to_f
+                - @car = row['CALC_SQKM'].to_f
+                - @ar = row['AREA_SQKM']
+                - @pv = 0
+                - @cl = row['CL95']
+                - @es = row['ESTIMATE']
+                - @lo = row['LON']
+                - @la = row['LAT']
+                - @n = @n + 1
+                - @ra = row['RA'].to_f
+            - @pf = (Math.log10((((@dp+0.001)/(@dpps+0.001))+1)/(@car/@ra))).round rescue '?'
+            tr
               td
-                div style='margin-left:20px;'
-                  a href="/population_submissions/#{row['population_submission_id']}" = row['stratum_name']
-              td= row['ReasonForChange']
-              td= row['method_and_quality'].gsub(/[\d]/,'')
-              td style="text-align:center" = row['CATEGORY']
-              td= row['CYEAR']
-              td.numeric= number_with_delimiter row['ESTIMATE']
-              td.numeric= row['CL95'].to_s.gsub(/[^\d]/, '')!="0" ? (number_with_delimiter row['CL95']) : ""
-              td style="padding-left:10px" = row['REFERENCE']
-              td style='text-align:center' = row['PFS']
-              td.numeric style="padding-right:10px" = number_with_delimiter row['AREA_SQKM']
-              td style='text-align:center' = row['LON']
-              td style='text-align:center' = row['LAT']
+                a href="javascript:toggle_section('#{@rn.gsub(/[^\w\d]/,'')}')" style='text-decoration:none'  +
+                '
+                = @rn
+              td= @cc
+              td= @ty
+              td style="text-align:center" = @ca
+              td= @yr
+              td style="text-align:right" = number_with_delimiter @es
+              -if @pv>0
+                td style="text-align:right" = number_with_delimiter ((Math.sqrt(@pv))*1.96).round
+              - else
+                td style="text-align:right" = @cl.to_s.gsub(/[^\d]/, "")!="0" ? number_with_delimiter(@cl) : ""
+              td style="padding-left:10px" = @re
+              td style="text-align:center" = @pf
+              td style="text-align:right" = @ar.to_s!="0" ? number_with_delimiter(@ar) : ""
+              td style="text-align:center" = @lo
+              td style="text-align:center" = @la
+            - group.each do |row|
+              tr data-section=("#{@rn.gsub(/[^\w\d]/,'')}") style=('height:18px; display:none')
+                td
+                  div style='margin-left:20px;'
+                    a href="/population_submissions/#{row['population_submission_id']}" = row['stratum_name']
+                td= row['ReasonForChange']
+                td= row['method_and_quality'].gsub(/[\d]/,'')
+                td style="text-align:center" = row['CATEGORY']
+                td= row['CYEAR']
+                td.numeric= number_with_delimiter row['ESTIMATE']
+                td.numeric= row['CL95'].to_s.gsub(/[^\d]/, '')!="0" ? (number_with_delimiter row['CL95']) : ""
+                td style="padding-left:10px" = row['REFERENCE']
+                td style='text-align:center' = row['PFS']
+                td.numeric style="padding-right:10px" = number_with_delimiter row['AREA_SQKM']
+                td style='text-align:center' = row['LON']
+                td style='text-align:center' = row['LAT']
 
-    == footnote
+      == footnote
 
-    p
-      | * Range of informed guess
-    p
-      sup 1
-      == t 'footnotes.causes_of_change'
-    p
-      sup 2
-      == t 'footnotes.survey_types'
-    p
-      sup 3
-      == t 'footnotes.pfs'
-    p
-      == t 'footnotes.derived_warning'
+      p
+        | * Range of informed guess
+      p
+        sup 1
+        == t 'footnotes.causes_of_change'
+      p
+        sup 2
+        == t 'footnotes.survey_types'
+      p
+        sup 3
+        == t 'footnotes.pfs'
+      p
+        == t 'footnotes.derived_warning'
 
-    javascript:
-      function toggle_section(key){
-        jQuery('*[data-section="'+key+'"]').toggle(300)
-      }
+javascript:
+  function toggle_section(key){
+    jQuery('*[data-section="'+key+'"]').toggle(300)
+  }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,6 +67,7 @@ Aaed::Application.routes.draw do
   get 'population_submissions/:id/map' => 'population_submissions#geojson_map'
   get 'survey_geometry/:id/map' => 'survey_geometries#geojson_map'
   get 'country/:iso_code/map' => 'countries#geojson_map'
+  get 'country/survey_map/:iso_code/:analysis/:year' => 'countries#geojson_map_public'
 
   get 'data_request_forms/thanks' => 'data_request_forms#thanks'
 


### PR DESCRIPTION
This shows a version of the Replacement Manager map on a tab in
the Country reports page. This is a largish commit because it
adds two new bits of plumbing: the ability to deferred load a
map on demand (as opposed to when the page is created) and also
some model mechanics for selectively including just those strata
included in a given analysis. These bits of plumbing should
be useful later in providing exports for printed report
generation. The model plumbing could be done with greater
efficiency by leveraging existing PostgreSQL views
if it needs to be accelerated -- with the tradeoff of tightly
binding the code to those views and needing to maintain both
SQL and Ruby code around this feature.

The map tab is only rendered at present for superusers, so this
code can be pushed to production without any public effects.

Test #418
Test #419