### PR TITLE
Revert and reintroduce "Disable changes form"

### DIFF
--- a/app/controllers/changes_controller.rb
+++ b/app/controllers/changes_controller.rb
@@ -1,0 +1,86 @@
+class ChangesController < ApplicationController
+
+  before_filter :authenticate_superuser!
+
+  # GET /changes
+  # GET /changes.json
+  def index
+    @changes = Change.order(:analysis_name,:analysis_year,:country,:replacement_name)
+
+    respond_to do |format|
+      format.html # index.html.erb
+      format.json { render json: @changes }
+    end
+  end
+
+  # GET /changes/1
+  # GET /changes/1.json
+  def show
+    @change = Change.find(params[:id])
+
+    respond_to do |format|
+      format.html # show.html.erb
+      format.json { render json: @change }
+    end
+  end
+
+  # GET /changes/new
+  # GET /changes/new.json
+  def new
+    @change = Change.new
+
+    respond_to do |format|
+      format.html # new.html.erb
+      format.json { render json: @change }
+    end
+  end
+
+  # GET /changes/1/edit
+  def edit
+    @change = Change.find(params[:id])
+  end
+
+  # POST /changes
+  # POST /changes.json
+  def create
+    @change = Change.new(params[:change])
+
+    respond_to do |format|
+      if @change.save
+        format.html { redirect_to @change, notice: 'Change was successfully created.' }
+        format.json { render json: @change, status: :created, location: @change }
+      else
+        format.html { render action: "new" }
+        format.json { render json: @change.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PUT /changes/1
+  # PUT /changes/1.json
+  def update
+    @change = Change.find(params[:id])
+
+    respond_to do |format|
+      if @change.update_attributes(params[:change])
+        format.html { redirect_to @change, notice: 'Change was successfully updated.' }
+        format.json { head :no_content }
+      else
+        format.html { render action: "edit" }
+        format.json { render json: @change.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /changes/1
+  # DELETE /changes/1.json
+  def destroy
+    @change = Change.find(params[:id])
+    @change.destroy
+
+    respond_to do |format|
+      format.html { redirect_to changes_url }
+      format.json { head :no_content }
+    end
+  end
+end

--- a/app/helpers/changes_helper.rb
+++ b/app/helpers/changes_helper.rb
@@ -1,0 +1,2 @@
+module ChangesHelper
+end

--- a/app/views/changes/_form.html.slim
+++ b/app/views/changes/_form.html.slim
@@ -1,0 +1,11 @@
+= semantic_form_for @change do |f|
+  = f.inputs do
+    = f.input :analysis_name
+    = f.input :analysis_year
+    = f.input :country, :as => :string
+    = f.input :replacement_name
+    = f.input :replaced_strata
+    = f.input :new_strata
+    = f.input :reason_change
+  = f.actions do
+    = f.submit

--- a/app/views/changes/edit.html.slim
+++ b/app/views/changes/edit.html.slim
@@ -1,0 +1,7 @@
+.row
+  .col-xs-12
+    h1= t '.title'
+    p
+      = link_to t('back'), changes_path
+      = link_to t('show'), @change
+    = render 'form'

--- a/app/views/changes/index.html.slim
+++ b/app/views/changes/index.html.slim
@@ -1,0 +1,30 @@
+.row
+  .col-xs-12
+    h1= t('.title')
+    p= link_to t('.new'), new_change_path
+
+    table.table
+      thead
+        tr
+          th= Change.human_attribute_name :analysis_name
+          th= Change.human_attribute_name :analysis_year
+          th= Change.human_attribute_name :country
+          th= Change.human_attribute_name :replacement_name
+          th= Change.human_attribute_name :replaced_strata
+          th= Change.human_attribute_name :new_strata
+          th= Change.human_attribute_name :reason_change
+          th colspan=3 = t 'actions'
+      
+      tbody
+        - for change in @changes
+          tr  class=cycle(:odd, :even)  
+            td= change.analysis_name
+            td= change.analysis_year
+            td= change.country
+            td= change.replacement_name
+            td= linked_ids_for change.replaced_strata
+            td= linked_ids_for change.new_strata
+            td= change.reason_change
+            td.action= link_to t('show'), change
+            td.action= link_to t('edit'), edit_change_path(change)
+            td.action= link_to t('destroy'), change, :confirm => t('are_you_sure'), :method => :delete

--- a/app/views/changes/new.html.slim
+++ b/app/views/changes/new.html.slim
@@ -1,0 +1,5 @@
+.row
+  .col-xs-12
+    h1= t '.title'
+    p= link_to t('back'), changes_path
+    = render 'form'

--- a/app/views/changes/show.html.slim
+++ b/app/views/changes/show.html.slim
@@ -1,0 +1,21 @@
+.row
+  .col-xs-12
+    h1= t '.title'
+    p
+      = link_to t('back'), changes_path
+      = link_to t('edit'), edit_change_path(@change)
+      = link_to t('.new'), new_change_path
+
+    dl
+      dt= Change.human_attribute_name :analysis_name
+      dd= @change.analysis_name
+      dt= Change.human_attribute_name :analysis_year
+      dd= @change.analysis_year
+      dt= Change.human_attribute_name :replacement_name
+      dd= @change.replacement_name
+      dt= Change.human_attribute_name :replaced_strata
+      dd= @change.replaced_strata
+      dt= Change.human_attribute_name :new_strata
+      dd= @change.new_strata
+      dt= Change.human_attribute_name :reason_change
+      dd= @change.reason_change

--- a/app/views/superuser/index.html.slim
+++ b/app/views/superuser/index.html.slim
@@ -10,9 +10,8 @@
         = link_to 'Users', '/users'
       h3
         = link_to 'All Narratives and Footnotes', '/report_narratives'
-      h3 Replacements
-      div = link_to 'Original replacement manager', '/changes'
-      div = link_to 'New replacement manager', '/analyses'
+      h3
+        = link_to 'Replacement Manager', '/analyses'
       h3
         = link_to '2013 Africa reports', '/preview_report/2013_africa_final/Loxodonta_africana/2013/Africa'
       h3

--- a/app/views/superuser/index.html.slim
+++ b/app/views/superuser/index.html.slim
@@ -10,8 +10,9 @@
         = link_to 'Users', '/users'
       h3
         = link_to 'All Narratives and Footnotes', '/report_narratives'
-      h3
-        = link_to 'Replacement Manager', '/analyses'
+      h3 Replacements
+      div = link_to 'Original replacement manager', '/changes'
+      div = link_to 'New replacement manager', '/analyses'
       h3
         = link_to '2013 Africa reports', '/preview_report/2013_africa_final/Loxodonta_africana/2013/Africa'
       h3

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,8 @@ Aaed::Application.routes.draw do
 
   devise_for :users
 
+  resources :changes
+
   resources :analyses
 
   resources :report_narratives


### PR DESCRIPTION
The underlying /changes plumbing is depended on by the new replacement manager, so can't strip it out.