### PR TITLE
Relink survey data files

### DIFF
--- a/db/migrate/20160131211655_recapture_s3_files.rb
+++ b/db/migrate/20160131211655_recapture_s3_files.rb
@@ -1,0 +1,28 @@
+require 'find'
+
+class RecaptureS3Files < ActiveRecord::Migration
+  def change
+    file_paths = []
+    Find.find('/u/s3') do |path|
+      file_paths << path
+    end
+    PopulationSubmissionAttachment.order(:id).each do |psa|
+      fn = psa.file_file_name
+      next if fn and fn.empty?
+      file_paths.each do |file_path|
+        if file_path.end_with? "#{psa.id}/#{fn}"
+          puts "#{psa.id}: found #{fn} at #{file_path}"
+          File.open(file_path) do |f|
+            psa.file = f
+            begin
+              psa.save!
+            rescue
+              puts "NOTICE: Could not save #{psa.id} -- please check file content"
+            end
+          end
+          break
+        end
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160125090447) do
+ActiveRecord::Schema.define(version: 20160131211655) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -460,29 +460,6 @@ ActiveRecord::Schema.define(version: 20160125090447) do
   end
 
   add_index "protected_area_geometries", ["geometry"], name: "protarea_the_geom_gist", using: :gist
-
-  create_table "protectedareaproj", primary_key: "gid", force: :cascade do |t|
-    t.decimal  "__gid",                                                 precision: 10
-    t.decimal  "ptacode",                                               precision: 10
-    t.string   "ptaname",    limit: 254
-    t.string   "ccode",      limit: 254
-    t.decimal  "year_est",                                              precision: 10
-    t.string   "iucncat",    limit: 254
-    t.decimal  "iucncatara",                                            precision: 10
-    t.string   "designate",  limit: 254
-    t.string   "abvdesig",   limit: 254
-    t.decimal  "area_sqkm",                                             precision: 10
-    t.decimal  "reported",                                              precision: 10
-    t.decimal  "calculated",                                            precision: 10
-    t.string   "source",     limit: 254
-    t.decimal  "refid",                                                 precision: 10
-    t.decimal  "inrange",                                               precision: 10
-    t.decimal  "samesurvey",                                            precision: 10
-    t.decimal  "shape_leng"
-    t.decimal  "shape_area"
-    t.decimal  "selection",                                             precision: 10
-    t.geometry "geom",       limit: {:srid=>0, :type=>"multi_polygon"}
-  end
 
   create_table "range_discrepancies", id: false, force: :cascade do |t|
     t.integer "gid"


### PR DESCRIPTION
This migration requires you have a copy of AfESG's S3 data spool in
/u/s3 with each bucket enumerated below. If you don't care about
relinking these files, you can just make a stub directory at /u/s3
to pass this migration.

When a corresponding ID and filename are found in the S3 spool, the
file is reattached and relinked to the PopulationSubmissionAttachment
exactly as if it had been resubmitted. This creates a paper_trail
entry for the change and makes a copy of the file in the appropriate
working directory.

Unless there are exact ID and filename matches in the S3 spool, this
migration should not clobber or evict any other attachements.

Test #455