### PR TITLE
Update Tables URL on 404

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -28,7 +28,7 @@
   <!-- This file lives in public/404.html -->
   <div class="dialog">
     <h1>The server couldn't find a page at this address.</h1>
-    <p>If you followed a link to get here, the page may have moved or is no longer available. Please visit the <a href='/'>homepage</a> or <a href='/preview_report/2013_africa_final/Loxodonta_africana/2013/Africa'>Tables</a>  to navigate to the country and year in which you are interested.</p>
+    <p>If you followed a link to get here, the page may have moved or is no longer available. Please visit the <a href='/'>homepage</a> or <a href='/preview_report/2013_africa_final/2013/Africa'>Tables</a>  to navigate to the country and year in which you are interested.</p>
     <p>We look forward to you continuing to explore the African Elephant Database!
   </div>
 </body>


### PR DESCRIPTION
The Tables URL on the 404 page still had /Loxodonta_africana in
the URL. I removed it.

See #465