### PR TITLE
Experimental shapefile downloader for superusers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,9 @@ gem 'capistrano-unicorn'
 gem 'protected_attributes'
 gem 'roo'
 
+# For shapefile writing support
+gem 'georuby'
+
 # Make ActiveRecord PostGIS-aware
 gem 'activerecord-postgis-adapter'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,6 +119,7 @@ GEM
       actionpack (>= 3.2.13)
     formtastic-bootstrap (3.1.1)
       formtastic (>= 3.0)
+    georuby (2.5.2)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     haml (4.0.7)
@@ -288,6 +289,7 @@ DEPENDENCIES
   devise
   formtastic
   formtastic-bootstrap
+  georuby
   haml
   hpricot
   jquery-rails

--- a/app/controllers/survey_geometries_controller.rb
+++ b/app/controllers/survey_geometries_controller.rb
@@ -1,9 +1,40 @@
 class SurveyGeometriesController < ApplicationController
 
+  include GeoRuby::SimpleFeatures
+  require 'geo_ruby/shp'
+  require 'geo_ruby/ewk'
+
   def geojson_map
     @survey_geometry = SurveyGeometry.find(params[:id])
     feature = RGeo::GeoJSON.encode(@survey_geometry.geom)
     render :json => feature
+  end
+
+  def download
+    i = params[:id]
+    @survey_geometry = SurveyGeometry.find(i)
+    fn = "#{i}.shp"
+    shpfile = GeoRuby::Shp4r::ShpFile.create(fn, GeoRuby::Shp4r::ShpType::POLYGON, [])
+    shpfile.transaction do |tr|
+      mp = MultiPolygon.from_ewkb(@survey_geometry.geom.as_binary)
+      record = GeoRuby::Shp4r::ShpRecord.new(mp,{})
+      tr.add(record)
+    end
+
+    input_filenames = ["#{i}.shp", "#{i}.dbf", "#{i}.shx"]
+    zipfile_name = "#{i}.zip"
+    File.delete(zipfile_name) rescue nil
+
+    Zip::File.open(zipfile_name, Zip::File::CREATE) do |zipfile|
+      input_filenames.each do |filename|
+        zipfile.add(filename, filename)
+      end
+    end
+    input_filenames.each do |filename|
+      File.delete(filename)
+    end
+
+    send_file zipfile_name, :type => "application/octet-stream", :x_sendfile => true
   end
 
 end

--- a/app/views/application/_map_stratum.html.slim
+++ b/app/views/application/_map_stratum.html.slim
@@ -11,3 +11,7 @@ javascript:
     survey_map.addTo(map);
     map.fitBounds(survey_map.getBounds());
   });
+
+- if current_user and current_user.admin?
+  = link_to "/survey_geometry/#{level.survey_geometry_id}/download", target: '_blank'
+    ' Download shapefile

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,6 +71,7 @@ Aaed::Application.routes.draw do
   get 'population_submission_attachments/download/:id' => 'population_submission_attachments#download'
   get 'population_submissions/:id/map' => 'population_submissions#geojson_map'
   get 'survey_geometry/:id/map' => 'survey_geometries#geojson_map'
+  get 'survey_geometry/:id/download' => 'survey_geometries#download'
   get 'country/:iso_code/map' => 'countries#geojson_map'
   get 'country/survey_map/:iso_code/:analysis/:year' => 'countries#geojson_map_public'
 


### PR DESCRIPTION
This will download a fairly basic shapefile of any stratum in
the system ... potentially useful for reusing these geometries
in other contexts.

Since RGeo's shapefile export is nonexistent, this reintroduces
GeoRuby.