### PR TITLE
Changed calculation method for other dung count.

### DIFF
--- a/app/models/sql_reader.rb
+++ b/app/models/sql_reader.rb
@@ -15,7 +15,7 @@ class SqlReader
       end
 
       sql << line
-      sql << ' ' unless line.blank?
+      sql << "\n" unless line.blank?
       if line.end_with?(';')
         found = true
         begin

--- a/app/views/report/appendix_2.html.slim
+++ b/app/views/report/appendix_2.html.slim
@@ -1,8 +1,15 @@
-table
-  tr
-  - @table[0].each do |k,v|
-    th= k
-  - @table.each do |row|
-    tr
-      - row.each do |k,v|
-        td= v
+.row
+  .col-xs-12
+    table.table
+      tr
+      - @table[0].each do |k,v|
+        th= k
+      - @table.each do |row|
+        tr
+          - row.each do |k,v|
+            - if k == 'estimate'
+              = numeric_cell v
+            - elsif k == 'confidence'
+              = numeric_cell v, precision: 2
+            - else
+              td = v

--- a/db/migrate/20160531062918_dung_count_guesses.rb
+++ b/db/migrate/20160531062918_dung_count_guesses.rb
@@ -1,0 +1,15 @@
+require 'sql_helper'
+
+class DungCountGuesses < ActiveRecord::Migration
+
+  include SqlHelper
+
+  def up
+    build_calculator '20160531'
+  end
+
+  def down
+    build_calculator '20160518'
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -17,27 +17,6 @@ ActiveRecord::Schema.define(version: 20160531135031) do
   enable_extension "plpgsql"
   enable_extension "postgis"
 
-  create_table "2014_range_map_edit_for_2016", primary_key: "gid", force: :cascade do |t|
-    t.integer  "range",      limit: 2
-    t.string   "rangequali", limit: 10
-    t.string   "ccode",      limit: 2
-    t.string   "cntryname",  limit: 30
-    t.integer  "area_sqkm"
-    t.integer  "refid"
-    t.string   "datastatus", limit: 2
-    t.string   "comments",   limit: 254
-    t.string   "rangetype",  limit: 20
-    t.string   "comments_1", limit: 254
-    t.string   "adjyear_1",  limit: 20
-    t.integer  "sourceyear", limit: 2
-    t.string   "publisyear", limit: 20
-    t.string   "2016",       limit: 20
-    t.string   "comnts2016", limit: 254
-    t.string   "ref_2016",   limit: 254
-    t.string   "chnges2016", limit: 254
-    t.geometry "geom",       limit: {:srid=>0, :type=>"multi_polygon"}
-  end
-
   create_table "2014_rangetypeupdates5_final", primary_key: "gid", force: :cascade do |t|
     t.integer  "range",      limit: 2
     t.string   "rangequali", limit: 10
@@ -73,17 +52,30 @@ ActiveRecord::Schema.define(version: 20160531135031) do
     t.geometry "survey_geometry",     limit: {:srid=>4326, :type=>"multi_polygon", :has_z=>true, :has_m=>true}
   end
 
+  create_table "add_sums_continent_category_reason", id: false, force: :cascade do |t|
+    t.string  "analysis_name"
+    t.integer "analysis_year"
+    t.string  "continent",                limit: 255
+    t.string  "reason_change"
+    t.decimal "estimate"
+    t.float   "confidence"
+    t.float   "guess_min"
+    t.float   "guess_max"
+    t.float   "meta_population_variance"
+  end
+
   create_table "add_sums_country_category_reason", id: false, force: :cascade do |t|
     t.string  "analysis_name"
     t.integer "analysis_year"
-    t.string  "continent",           limit: 255
-    t.string  "region",              limit: 255
-    t.string  "country",             limit: 255
+    t.string  "continent",                limit: 255
+    t.string  "region",                   limit: 255
+    t.string  "country",                  limit: 255
     t.string  "reason_change"
     t.decimal "estimate"
-    t.float   "population_variance"
-    t.decimal "guess_min"
-    t.decimal "guess_max"
+    t.float   "confidence"
+    t.float   "guess_min"
+    t.float   "guess_max"
+    t.float   "meta_population_variance"
   end
 
   create_table "add_sums_country_reason_raw", id: false, force: :cascade do |t|
@@ -99,14 +91,27 @@ ActiveRecord::Schema.define(version: 20160531135031) do
     t.decimal "guess_max"
   end
 
+  create_table "add_sums_region_category_reason", id: false, force: :cascade do |t|
+    t.string  "analysis_name"
+    t.integer "analysis_year"
+    t.string  "continent",                limit: 255
+    t.string  "region",                   limit: 255
+    t.string  "reason_change"
+    t.decimal "estimate"
+    t.float   "confidence"
+    t.float   "guess_min"
+    t.float   "guess_max"
+    t.float   "meta_population_variance"
+  end
+
   create_table "add_totals_continent_category_reason", id: false, force: :cascade do |t|
     t.string  "analysis_name"
     t.integer "analysis_year"
     t.string  "continent",     limit: 255
     t.decimal "estimate"
     t.float   "confidence"
-    t.decimal "guess_min"
-    t.decimal "guess_max"
+    t.float   "guess_min"
+    t.float   "guess_max"
   end
 
   create_table "add_totals_country_category_reason", id: false, force: :cascade do |t|
@@ -117,8 +122,8 @@ ActiveRecord::Schema.define(version: 20160531135031) do
     t.string  "country",       limit: 255
     t.decimal "estimate"
     t.float   "confidence"
-    t.decimal "guess_min"
-    t.decimal "guess_max"
+    t.float   "guess_min"
+    t.float   "guess_max"
   end
 
   create_table "add_totals_region_category_reason", id: false, force: :cascade do |t|
@@ -128,8 +133,8 @@ ActiveRecord::Schema.define(version: 20160531135031) do
     t.string  "region",        limit: 255
     t.decimal "estimate"
     t.float   "confidence"
-    t.decimal "guess_min"
-    t.decimal "guess_max"
+    t.float   "guess_min"
+    t.float   "guess_max"
   end
 
   create_table "analyses", force: :cascade do |t|

--- a/script/calculator/20160531/1000_flush_analyses_view_dependencies.sql
+++ b/script/calculator/20160531/1000_flush_analyses_view_dependencies.sql
@@ -1,0 +1,9 @@
+-- Destroys the dependencies on the 'analyses' table
+-- so it can be modified
+
+drop view if exists estimate_factors_analyses cascade;
+drop view if exists actual_diff_country cascade;
+drop view if exists actual_diff_region cascade;
+drop view if exists actual_diff_continent cascade;
+drop view if exists new_strata cascade;
+drop view if exists replaced_strata cascade;

--- a/script/calculator/20160531/1100_new_estimates_views.sql
+++ b/script/calculator/20160531/1100_new_estimates_views.sql
@@ -1,0 +1,593 @@
+---
+--- estimate_factors
+---
+--- The purpose of this view is to standardize the factors in the various
+--- survey strata or count tables so that common operations involved in
+--- pooling can be performed on them.
+---
+drop view estimate_factors cascade;
+create or replace view estimate_factors as
+select
+  'GT'::text estimate_type,
+  'GT'||survey_ground_total_count_strata.id input_zone_id,
+  population_submission_id,
+  site_name,
+  stratum_name,
+  stratum_area,
+  completion_year,
+  citation,
+  short_citation,
+  population_estimate,
+  population_variance,
+  population_standard_error,
+  population_confidence_interval,
+  population_t,
+  population_lower_confidence_limit,
+  population_upper_confidence_limit,
+  1 quality_level,
+  actually_seen,
+  survey_geometry_id
+  from
+    survey_ground_total_count_strata
+    join survey_ground_total_counts on survey_ground_total_counts.id=survey_ground_total_count_id
+    join population_submissions on population_submissions.id=population_submission_id
+union
+select
+  'DC',
+  'DC'||survey_dung_count_line_transect_strata.id input_zone_id,
+  population_submission_id,
+  site_name,
+  stratum_name,
+  stratum_area,
+  completion_year,
+  citation,
+  short_citation,
+  population_estimate,
+  population_variance,
+  population_standard_error,
+  population_confidence_interval,
+  population_t,
+  population_lower_confidence_limit,
+  population_upper_confidence_limit,
+  CASE
+    WHEN dung_decay_rate_measurement_method != 'Decay rate NOT measured on site' and dung_decay_rate_measurement_site != '' THEN 1
+    ELSE 0
+  END quality_level,
+  actually_seen,
+  survey_geometry_id
+from
+  survey_dung_count_line_transect_strata
+  join survey_dung_count_line_transects on survey_dung_count_line_transects.id=survey_dung_count_line_transect_id
+  join population_submissions on population_submissions.id=population_submission_id
+union
+select
+  'AT',
+  'AT'||survey_aerial_total_count_strata.id input_zone_id,
+  population_submission_id,
+  site_name,
+  stratum_name,
+  stratum_area,
+  completion_year,
+  citation,
+  short_citation,
+  population_estimate,
+  population_variance,
+  population_standard_error,
+  population_confidence_interval,
+  population_t,
+  population_lower_confidence_limit,
+  population_upper_confidence_limit,
+  1 quality_level,
+  observations actually_seen,
+  survey_geometry_id
+from
+  survey_aerial_total_count_strata
+  join survey_aerial_total_counts on survey_aerial_total_counts.id=survey_aerial_total_count_id
+  join population_submissions on population_submissions.id=population_submission_id
+union
+select
+  'GS',
+  'GS'||survey_ground_sample_count_strata.id input_zone_id,
+  population_submission_id,
+  site_name,
+  stratum_name,
+  stratum_area,
+  completion_year,
+  citation,
+  short_citation,
+  population_estimate,
+  population_variance,
+  population_standard_error,
+  population_confidence_interval,
+  population_t,
+  population_lower_confidence_limit,
+  population_upper_confidence_limit,
+  1 quality_level,
+  NULL actually_seen,
+  survey_geometry_id
+from
+  survey_ground_sample_count_strata
+  join survey_ground_sample_counts on survey_ground_sample_counts.id=survey_ground_sample_count_id
+  join population_submissions on population_submissions.id=population_submission_id
+union
+select
+  'AS',
+  'AS'||survey_aerial_sample_count_strata.id input_zone_id,
+  population_submission_id,
+  site_name,
+  stratum_name,
+  stratum_area,
+  completion_year,
+  citation,
+  short_citation,
+  population_estimate,
+  population_variance,
+  population_standard_error,
+  population_confidence_interval,
+  population_t,
+  population_lower_confidence_limit,
+  population_upper_confidence_limit,
+  1 quality_level,
+  seen_in_transects actually_seen,
+  survey_geometry_id
+from survey_aerial_sample_count_strata
+  join survey_aerial_sample_counts on survey_aerial_sample_counts.id=survey_aerial_sample_count_id
+  join population_submissions on population_submissions.id=population_submission_id
+union
+select
+  'GD',
+  'GD'||survey_faecal_dna_strata.id input_zone_id,
+  population_submission_id,
+  site_name,
+  stratum_name,
+  stratum_area,
+  completion_year,
+  citation,
+  short_citation,
+  population_estimate,
+  population_variance,
+  population_standard_error,
+  population_confidence_interval,
+  population_t,
+  population_lower_confidence_limit,
+  population_upper_confidence_limit,
+  1 quality_level,
+  genotypes_identified actually_seen,
+  survey_geometry_id
+from survey_faecal_dna_strata
+  join survey_faecal_dnas on survey_faecal_dnas.id=survey_faecal_dna_id
+  join population_submissions on population_submissions.id=population_submission_id
+union
+select
+  'IR',
+  'IR'||survey_individual_registrations.id input_zone_id,
+  population_submission_id,
+  site_name,
+  site_name,
+  area,
+  completion_year,
+  citation,
+  short_citation,
+  population_estimate,
+  NULL population_variance,
+  NULL population_standard_error,
+  NULL population_confidence_interval,
+  NULL population_t,
+  NULL population_lower_confidence_limit,
+  population_upper_range population_upper_confidence_limit,
+  CASE
+    WHEN population_upper_range is null THEN 1
+    ELSE 0
+  END quality_level,
+  population_estimate actually_seen,
+  survey_geometry_id
+from survey_individual_registrations
+  join population_submissions on population_submissions.id=population_submission_id
+union
+select
+  'O',
+  'O'||survey_others.id input_zone_id,
+  population_submission_id,
+  site_name,
+  site_name,
+  area,
+  completion_year,
+  citation,
+  short_citation,
+  CASE
+    WHEN informed=false THEN
+      (population_estimate_min+population_estimate_max)/2
+    ELSE
+      population_estimate_min
+  END,
+  NULL population_variance,
+  NULL population_standard_error,
+  NULL population_confidence_interval,
+  NULL population_t,
+  population_estimate_min lower_confidence_limit,
+  population_estimate_max population_upper_confidence_limit,
+  CASE
+    WHEN informed=true THEN 1
+    ELSE 0
+  END quality_level,
+  actually_seen,
+  survey_geometry_id
+from survey_others
+  join population_submissions on population_submissions.id=population_submission_id
+;
+
+---
+--- estimate_factors_confidence
+---
+--- This view calculates population_variance or population_confidence_interval
+--- if they are missing
+---
+drop view if exists estimate_factors_confidence;
+create view estimate_factors_confidence as
+select
+  estimate_type,
+  input_zone_id,
+  population_submission_id,
+  site_name,
+  stratum_name,
+  stratum_area,
+  completion_year,
+  citation,
+  short_citation,
+  quality_level,
+  population_estimate,
+  CASE
+    WHEN population_variance IS NOT NULL
+    THEN population_variance
+    WHEN population_standard_error IS NOT NULL
+    THEN population_standard_error ^ 2
+    WHEN population_confidence_interval IS NOT NULL
+         AND population_t IS NOT NULL
+    THEN (population_confidence_interval/population_t) ^ 2
+    WHEN population_confidence_interval IS NOT NULL
+    THEN (population_confidence_interval/1.96) ^ 2
+    ELSE null
+  END population_variance,
+  population_standard_error,
+  CASE
+    WHEN population_confidence_interval IS NOT NULL
+    THEN population_confidence_interval
+    WHEN population_standard_error IS NOT NULL
+    THEN population_standard_error * 1.96
+    WHEN population_standard_error IS NOT NULL
+         AND population_t IS NOT NULL
+    THEN population_standard_error * population_t
+    WHEN population_variance IS NOT NULL
+    THEN SQRT(population_variance) * 1.96
+    ELSE null
+  END population_confidence_interval,
+  population_lower_confidence_limit,
+  population_upper_confidence_limit,
+  CASE WHEN actually_seen IS NULL THEN 0 ELSE actually_seen END actually_seen
+  from
+    estimate_factors;
+
+---
+--- new_strata and replaced_strata
+---
+--- expand the CSV columns stored in the changes table
+---
+drop view if exists new_strata cascade;
+create view new_strata as
+ SELECT q.analysis_name,q.sort_key,q.population,q.replacement_name,q.reason_change,q.new_stratum
+   FROM ( SELECT DISTINCT analysis_name, sort_key, population, replacement_name, reason_change, unnest(regexp_split_to_array(changes.new_strata, ','::text)) AS new_stratum
+           FROM changes) q
+  WHERE q.new_stratum IS NOT NULL AND q.new_stratum <> ''::text
+  ORDER BY q.analysis_name, q.sort_key, q.reason_change, q.new_stratum;
+
+drop view if exists replaced_strata cascade;
+create view replaced_strata as
+ SELECT q.analysis_name,q.sort_key,q.population,q.replacement_name,'-'::text reason_change,q.replaced_stratum
+   FROM ( SELECT DISTINCT analysis_name, sort_key, population, replacement_name, unnest(regexp_split_to_array(changes.replaced_strata, ','::text)) AS replaced_stratum
+           FROM changes) q
+  WHERE q.replaced_stratum IS NOT NULL AND q.replaced_stratum <> ''::text
+  ORDER BY q.analysis_name, q.sort_key, q.replaced_stratum;
+
+---
+--- estimate_factors_analyses
+---
+--- Extracts the factors by analysis in context of the target year
+---
+drop view if exists estimate_factors_analyses;
+create view estimate_factors_analyses as
+select
+  estimate_type,
+  input_zone_id,
+  population_submission_id,
+  site_name,
+  stratum_name,
+  stratum_area,
+  completion_year,
+  a.analysis_name,
+  a.analysis_year,
+  a.comparison_year,
+  a.analysis_year - completion_year age,
+  n.sort_key,
+  n.population,
+  n.replacement_name,
+  reason_change,
+  citation,
+  short_citation,
+  population_estimate,
+  population_variance,
+  population_standard_error,
+  population_confidence_interval,
+  population_lower_confidence_limit,
+  population_upper_confidence_limit,
+  quality_level,
+  actually_seen
+  from
+    estimate_factors_confidence
+  join new_strata n on n.new_stratum = input_zone_id
+  join analyses a on a.analysis_name = n.analysis_name
+union
+select
+  estimate_type,
+  input_zone_id,
+  population_submission_id,
+  site_name,
+  stratum_name,
+  stratum_area,
+  completion_year,
+  a.analysis_name,
+  a.comparison_year,
+  a.comparison_year,
+  a.comparison_year - completion_year age,
+  r.sort_key,
+  r.population,
+  r.replacement_name,
+  reason_change,
+  citation,
+  short_citation,
+  population_estimate,
+  population_variance,
+  population_standard_error,
+  population_confidence_interval,
+  population_lower_confidence_limit,
+  population_upper_confidence_limit,
+  quality_level,
+  actually_seen
+  from
+    estimate_factors_confidence
+  join replaced_strata r on r.replaced_stratum = input_zone_id
+  join analyses a on a.analysis_name = r.analysis_name
+;
+
+---
+--- estimate_factors_analyses_categorized
+---
+--- Applies the categorization rules (type, age, confidence).
+--- Adds the synthetic LCL95 value used in pooling.
+---
+drop view if exists estimate_factors_analyses_categorized;
+create or replace view estimate_factors_analyses_categorized as
+select
+  estimate_type,
+  input_zone_id,
+  population_submission_id,
+  site_name,
+  stratum_name,
+  stratum_area,
+  completion_year,
+  analysis_name,
+  analysis_year,
+  age,
+  sort_key,
+  population,
+  replacement_name,
+  CAST(CASE
+      WHEN reason_change = '-' and age >= 10 and (comparison_year - completion_year <= 10) AND NOT (estimate_type='O' and (quality_level IS NULL or quality_level != 1)) THEN 'DD'
+      ELSE reason_change
+  END AS varchar(255)) reason_change,
+  citation,
+  short_citation,
+  population_estimate,
+  population_variance,
+  population_standard_error,
+  population_confidence_interval,
+  population_lower_confidence_limit,
+  population_upper_confidence_limit,
+  quality_level,
+  actually_seen,
+  CASE
+    WHEN population_lower_confidence_limit IS NOT NULL
+      THEN population_lower_confidence_limit
+    WHEN population_confidence_interval<population_estimate
+      THEN population_estimate-population_confidence_interval
+    ELSE 0
+  END lcl95,
+  CASE
+
+    /* old surveys always 'E' */
+
+    WHEN age>=10 THEN 'E'
+
+    /*  dung counts */
+
+    WHEN estimate_type='DC' THEN
+      CASE
+        WHEN quality_level=1 THEN 'B'
+        WHEN (population_variance IS NULL and population_standard_error IS NULL) THEN 'D'
+        ELSE 'C'
+      END
+
+    WHEN estimate_type='GD' AND analysis_year>2007 THEN 'A'
+    WHEN estimate_type='GD' AND analysis_year<=2007 THEN 'C'
+
+    /* totals */
+
+    WHEN (estimate_type='AT' or estimate_type='GT') THEN 'A'
+
+    /* samples */
+
+    WHEN (estimate_type='AS' or estimate_type='GS') THEN
+      CASE WHEN population_variance IS NOT NULL THEN 'B' ELSE 'D' END
+
+    /* individual registrations */
+
+    WHEN estimate_type='IR' THEN
+      CASE WHEN quality_level = 1 THEN 'A' ELSE 'D' END
+
+    /*  others */
+
+    WHEN estimate_type='O' THEN
+      CASE WHEN quality_level = 1 THEN 'D' ELSE 'E' END
+
+    /* a meaningless value 'F' for anything that fell through */
+
+    ELSE 'F'
+
+  END category
+  from
+    estimate_factors_analyses
+;
+
+drop view if exists estimate_locator;
+create or replace view estimate_locator as
+select
+  e.*,
+  countries.name country,
+  regions.name region,
+  continents.name continent
+from estimate_factors_analyses_categorized e
+join population_submissions on population_submission_id=population_submissions.id
+join submissions on submission_id=submissions.id
+join countries on country_id=countries.id
+join regions on region_id=regions.id
+join continents on continent_id=continents.id
+;
+
+---
+--- estimate_dpps
+---
+--- Row-level DPPS is useful for consistency check only
+---
+drop view if exists estimate_dpps;
+create or replace view estimate_dpps as
+select
+  analysis_name,
+  analysis_year,
+  input_zone_id,
+  category,
+  population_estimate,
+  population_estimate as definite,
+  0 as probable,
+  0 as possible,
+  0 as speculative
+from
+  estimate_factors_analyses_categorized
+where
+  category='A'
+union
+select
+  analysis_name,
+  analysis_year,
+  input_zone_id,
+  category,
+  population_estimate,
+  CASE
+    WHEN lcl95>actually_seen THEN lcl95
+    ELSE actually_seen
+  END as definite,
+  CASE WHEN lcl95>0 or actually_seen>0 THEN
+    population_estimate-(CASE
+      WHEN lcl95>actually_seen THEN lcl95
+      ELSE actually_seen
+    END)
+    ELSE population_estimate
+  END as probable,
+  population_confidence_interval as possible,
+  0 as speculative
+from
+  estimate_factors_analyses_categorized
+where
+  category='B'
+union
+select
+  analysis_name,
+  analysis_year,
+  input_zone_id,
+  category,
+  population_estimate,
+  CASE
+    WHEN actually_seen>0 THEN actually_seen
+    ELSE 0
+  END
+  as definite,
+  population_estimate as probable,
+  CASE WHEN lcl95>0 or actually_seen>0 THEN
+    population_estimate-(CASE
+      WHEN lcl95>actually_seen THEN lcl95
+      ELSE actually_seen
+    END)
+    ELSE 0
+  END as possible,
+  0 as speculative
+from
+  estimate_factors_analyses_categorized
+where
+  category='C'
+union
+select
+  analysis_name,
+  analysis_year,
+  input_zone_id,
+  category,
+  population_estimate,
+  CASE
+    WHEN actually_seen>0 THEN actually_seen
+    ELSE 0
+  END
+  as definite,
+  0 as probable,
+  CASE
+    WHEN actually_seen>0 THEN
+      population_estimate-actually_seen
+    ELSE
+      population_estimate
+  END as possible,
+  CASE WHEN lcl95>0 and lcl95!=population_estimate THEN (population_estimate-lcl95)*2
+  WHEN population_upper_confidence_limit>0 THEN
+    population_upper_confidence_limit-population_estimate
+  ELSE 0
+  END as speculative
+from
+  estimate_factors_analyses_categorized
+where
+  category='D'
+union
+select
+  analysis_name,
+  analysis_year,
+  input_zone_id,
+  category,
+  population_estimate,
+  CASE
+    WHEN actually_seen>0 THEN actually_seen
+    ELSE 0
+  END
+  as definite,
+  0 as probable,
+  0 as possible,
+  population_estimate-actually_seen as speculative
+from
+  estimate_factors_analyses_categorized
+where
+  category='E'
+;
+
+create view estimate_locator_with_geometry as
+select
+  g.id as id,
+  l.*,
+  g.geom
+from survey_geometries g
+  join estimate_factors f
+    on f.survey_geometry_id = g.id
+  join estimate_locator l
+    on l.input_zone_id = f.input_zone_id;

--- a/script/calculator/20160531/1110_estimate_factors_analyses_categorized_for_add.sql
+++ b/script/calculator/20160531/1110_estimate_factors_analyses_categorized_for_add.sql
@@ -1,0 +1,464 @@
+CREATE OR REPLACE VIEW estimate_factors_analyses_categorized_for_add AS
+  SELECT
+    m.estimate_type,
+    m.category,
+    (st.surveytype || '')::varchar as surveytype,
+    m.analysis_name,
+    m.analysis_year,
+    m.completion_year,
+    ct.name as continent,
+    r.name as region,
+    c.name as country,
+    m.site_name,
+    m.best_estimate,
+    m.best_population_variance,
+    m.population_estimate,
+    m.population_variance,
+    m.population_lower_confidence_limit,
+    m.population_upper_confidence_limit,
+    m.actually_seen,
+    m.input_zone_id,
+    m.population_submission_id,
+    m.stratum_name,
+    m.stratum_area,
+    m.age,
+    m.replacement_name,
+    m.reason_change,
+    m.citation,
+    m.short_citation,
+    m.population_standard_error,
+    m.population_confidence_interval,
+    m.lcl95,
+    m.quality_level
+  FROM (
+    SELECT e.estimate_type,
+      CASE
+      WHEN e.estimate_type = 'GD' THEN 'N'
+      WHEN e.estimate_type = 'AT' THEN 'H'
+      WHEN e.estimate_type = 'GT' THEN 'I'
+      WHEN e.estimate_type = 'IR' THEN 'M'
+      ELSE 'U'
+      END AS category,
+      e.analysis_name,
+      e.analysis_year,
+      e.completion_year,
+      e.site_name,
+      e.population_estimate as best_estimate,
+      0 AS best_population_variance,
+      e.population_estimate,
+      e.population_variance,
+      0 AS population_lower_confidence_limit,
+      0 AS population_upper_confidence_limit,
+      e.actually_seen,
+      e.input_zone_id,
+      e.population_submission_id,
+      e.stratum_name,
+      e.stratum_area,
+      e.age,
+      e.replacement_name,
+      e.reason_change,
+      e.citation,
+      e.short_citation,
+      e.population_confidence_interval,
+      e.population_standard_error,
+      e.lcl95,
+      e.quality_level
+    FROM estimate_factors_analyses_categorized e
+    WHERE e.category = 'A'
+   UNION
+    SELECT e.estimate_type,
+      CASE
+      WHEN e.estimate_type = 'DC' THEN 'L'
+      WHEN e.estimate_type = 'AS' THEN 'J'
+      WHEN e.estimate_type = 'GS' THEN 'K'
+      ELSE 'U'
+      END AS category,
+      e.analysis_name,
+      e.analysis_year,
+      e.completion_year,
+      e.site_name,
+      CASE
+        WHEN e.population_estimate IS NULL OR e.population_estimate = 0 THEN e.actually_seen
+        ELSE e.population_estimate
+      END AS best_estimate,
+      e.population_variance as best_population_variance,
+      e.population_estimate,
+      e.population_variance,
+      0 AS population_lower_confidence_limit,
+      0 AS population_upper_confidence_limit,
+      e.actually_seen,
+      e.input_zone_id,
+      e.population_submission_id,
+      e.stratum_name,
+      e.stratum_area,
+      e.age,
+      e.replacement_name,
+      e.reason_change,
+      e.citation,
+      e.short_citation,
+      e.population_confidence_interval,
+      e.population_standard_error,
+      e.lcl95,
+      e.quality_level
+    FROM estimate_factors_analyses_categorized e
+    JOIN surveytypes st ON e.category = st.category
+    WHERE e.category = 'B'
+   UNION
+    SELECT e.estimate_type,
+      e.category,
+      e.analysis_name,
+      e.analysis_year,
+      e.completion_year,
+      e.site_name,
+      e.actually_seen as best_estimate,
+      0 as best_population_variance,
+      e.population_estimate,
+      e.population_variance,
+      CASE
+        WHEN e.population_lower_confidence_limit IS NULL OR e.population_upper_confidence_limit IS NULL 
+          OR (e.population_lower_confidence_limit = 0 AND e.population_upper_confidence_limit = 0) 
+          THEN e.population_estimate - e.actually_seen
+        ELSE e.population_lower_confidence_limit - e.actually_seen
+      END AS population_lower_confidence_limit,
+      CASE
+        WHEN e.population_lower_confidence_limit IS NULL OR e.population_upper_confidence_limit IS NULL 
+          OR (e.population_lower_confidence_limit = 0 AND e.population_upper_confidence_limit = 0) 
+          THEN e.population_estimate - e.actually_seen
+        ELSE e.population_upper_confidence_limit - e.actually_seen
+      END AS population_upper_confidence_limit,
+      e.actually_seen,
+      e.input_zone_id,
+      e.population_submission_id,
+      e.stratum_name,
+      e.stratum_area,
+      e.age,
+      e.replacement_name,
+      e.reason_change,
+      e.citation,
+      e.short_citation,
+      e.population_confidence_interval,
+      e.population_standard_error,
+      e.lcl95,
+      e.quality_level
+    FROM estimate_factors_analyses_categorized e
+    WHERE e.category = 'C'
+   UNION
+    SELECT e.estimate_type,
+      e.category,
+      e.analysis_name,
+      e.analysis_year,
+      e.completion_year,
+      e.site_name,
+      e.actually_seen as best_estimate,
+      0 as best_population_variance,
+      e.population_estimate,
+      e.population_variance,
+      CASE
+        WHEN e.population_lower_confidence_limit IS NULL OR e.population_upper_confidence_limit IS NULL 
+          OR (e.population_lower_confidence_limit = 0 AND e.population_upper_confidence_limit = 0) 
+          THEN e.population_estimate - e.actually_seen
+        ELSE e.population_lower_confidence_limit - e.actually_seen
+      END AS population_lower_confidence_limit,
+      CASE
+        WHEN e.population_lower_confidence_limit IS NULL OR e.population_upper_confidence_limit IS NULL 
+          OR (e.population_lower_confidence_limit = 0 AND e.population_upper_confidence_limit = 0) 
+          THEN e.population_estimate - e.actually_seen
+        ELSE e.population_upper_confidence_limit - e.actually_seen
+      END AS population_upper_confidence_limit,
+      e.actually_seen,
+      e.input_zone_id,
+      e.population_submission_id,
+      e.stratum_name,
+      e.stratum_area,
+      e.age,
+      e.replacement_name,
+      e.reason_change,
+      e.citation,
+      e.short_citation,
+      e.population_confidence_interval,
+      e.population_standard_error,
+      e.lcl95,
+      e.quality_level
+    FROM estimate_factors_analyses_categorized e
+    WHERE e.category = 'D' AND e.site_name <> 'Rest of Gabon'
+   UNION
+    SELECT e.estimate_type,
+      e.category,
+      e.analysis_name,
+      e.analysis_year,
+      e.completion_year,
+      e.site_name,
+      0 as best_estimate,
+      0 as best_population_variance,
+      0 as population_estimate,
+      0 as population_variance,
+      CASE
+        WHEN e.population_lower_confidence_limit IS NULL OR e.population_upper_confidence_limit IS NULL 
+          OR (e.population_lower_confidence_limit = 0 AND e.population_upper_confidence_limit = 0) 
+          THEN e.population_estimate - e.actually_seen
+        ELSE e.population_lower_confidence_limit - e.actually_seen
+      END AS population_lower_confidence_limit,
+      CASE
+        WHEN e.population_lower_confidence_limit IS NULL OR e.population_upper_confidence_limit IS NULL 
+          OR (e.population_lower_confidence_limit = 0 AND e.population_upper_confidence_limit = 0) 
+          THEN e.population_estimate - e.actually_seen
+        ELSE e.population_upper_confidence_limit - e.actually_seen
+      END AS population_upper_confidence_limit,
+      0 as actually_seen,
+      e.input_zone_id,
+      e.population_submission_id,
+      e.stratum_name,
+      e.stratum_area,
+      e.age,
+      e.replacement_name,
+      e.reason_change,
+      e.citation,
+      e.short_citation,
+      e.population_confidence_interval,
+      e.population_standard_error,
+      e.lcl95,
+      e.quality_level
+    FROM estimate_factors_analyses_categorized e
+    WHERE e.category = 'E' AND e.completion_year > e.analysis_year - 10
+   UNION
+    SELECT e.estimate_type,
+      'F' AS category,
+      e.analysis_name,
+      e.analysis_year,
+      e.completion_year,
+      e.site_name,
+      0 AS best_estimate,
+      0 as best_population_variance,
+      e.population_estimate,
+      e.population_variance,
+      e.population_estimate AS population_lower_confidence_limit,
+      e.population_estimate AS population_upper_confidence_limit,
+      e.actually_seen,
+      e.input_zone_id,
+      e.population_submission_id,
+      e.stratum_name,
+      e.stratum_area,
+      e.age,
+      e.replacement_name,
+      e.reason_change,
+      e.citation,
+      e.short_citation,
+      e.population_confidence_interval,
+      e.population_standard_error,
+      e.lcl95,
+      e.quality_level
+    FROM estimate_factors_analyses_categorized e
+    WHERE e.category = 'E' AND e.completion_year <= e.analysis_year - 10
+   UNION
+    SELECT e.estimate_type,
+      'G' as category,
+      e.analysis_name,
+      e.analysis_year,
+      e.completion_year,
+      e.site_name,
+      0 as best_estimate,
+      0 as best_population_variance,
+      e.population_estimate,
+      e.population_variance,
+      e.population_estimate AS population_lower_confidence_limit,
+      e.population_estimate AS population_upper_confidence_limit,
+      e.actually_seen,
+      e.input_zone_id,
+      e.population_submission_id,
+      e.stratum_name,
+      e.stratum_area,
+      e.age,
+      e.replacement_name,
+      e.reason_change,
+      e.citation,
+      e.short_citation,
+      e.population_confidence_interval,
+      e.population_standard_error,
+      e.lcl95,
+      e.quality_level
+    FROM estimate_factors_analyses_categorized e
+    WHERE e.category = 'G' OR (e.category = 'D' AND e.site_name = 'Rest of Gabon')
+  ) m
+  JOIN surveytypes st ON m.category = st.category
+  JOIN population_submissions ps ON ps.id = m.population_submission_id
+  JOIN submissions s ON ps.submission_id = s.id
+  JOIN countries c ON s.country_id = c.id
+  JOIN regions r ON c.region_id = r.id
+  JOIN continents ct ON r.continent_id = ct.id;
+
+CREATE OR REPLACE VIEW estimate_factors_analyses_categorized_sums_country_for_add AS
+  SELECT
+    e.category as "CATEGORY",
+    surveytype as "SURVEYTYPE",
+    analysis_year,
+    analysis_name,
+    continent,
+    region,
+    country,
+    sum(e.best_estimate) as "ESTIMATE",
+    1.96*sqrt(sum(e.best_population_variance)) as "CONFIDENCE",
+    sum(e.population_lower_confidence_limit) as "GUESS_MIN",
+    sum(e.population_upper_confidence_limit) as "GUESS_MAX",
+    sum(e.population_variance) as population_variance
+  FROM
+    estimate_factors_analyses_categorized_for_add e
+  WHERE
+    e.category <> 'C'
+  GROUP BY "CATEGORY", "SURVEYTYPE", analysis_year, analysis_name, continent, region, country
+
+  UNION
+
+  SELECT
+    e.category as "CATEGORY",
+    surveytype as "SURVEYTYPE",
+    analysis_year,
+    analysis_name,
+    continent,
+    region,
+    country,
+    sum(e.best_estimate) as "ESTIMATE",
+    0 as "CONFIDENCE",
+    sum(e.population_lower_confidence_limit) + 1.96*sqrt(sum(population_variance)) as "GUESS_MIN",
+    sum(e.population_upper_confidence_limit) + 1.96*sqrt(sum(population_variance)) as "GUESS_MAX",
+    sum(e.population_variance) as population_variance
+  FROM
+    estimate_factors_analyses_categorized_for_add e
+  WHERE 
+    e.category = 'C'
+  GROUP BY "CATEGORY", "SURVEYTYPE", analysis_year, analysis_name, continent, region, country
+
+  ORDER BY "CATEGORY";
+
+CREATE OR REPLACE VIEW estimate_factors_analyses_categorized_totals_country_for_add AS
+  SELECT
+    analysis_name,
+    analysis_year,
+    continent,
+    region,
+    country,
+    sum("ESTIMATE") "ESTIMATE",
+    1.96*sqrt(sum(population_variance)) "CONFIDENCE",
+    sum("GUESS_MIN") "GUESS_MIN",
+    sum("GUESS_MAX") "GUESS_MAX"
+  FROM estimate_factors_analyses_categorized_sums_country_for_add
+  GROUP BY analysis_name, analysis_year, continent, region, country;
+
+CREATE OR REPLACE VIEW estimate_factors_analyses_categorized_sums_region_for_add AS
+  SELECT
+    e.category as "CATEGORY",
+    surveytype as "SURVEYTYPE",
+    analysis_year,
+    analysis_name,
+    continent,
+    region,
+    sum(e.best_estimate) as "ESTIMATE",
+    1.96*sqrt(sum(e.best_population_variance)) as "CONFIDENCE",
+    sum(e.population_lower_confidence_limit) as "GUESS_MIN",
+    sum(e.population_upper_confidence_limit) as "GUESS_MAX",
+    sum(e.population_variance) population_variance
+  FROM
+    estimate_factors_analyses_categorized_for_add e
+  WHERE
+    e.category <> 'C'
+  GROUP BY "CATEGORY", "SURVEYTYPE", analysis_year, analysis_name, continent, region
+
+  UNION
+
+  SELECT
+    e.category as "CATEGORY",
+    surveytype as "SURVEYTYPE",
+    analysis_year,
+    analysis_name,
+    continent,
+    region,
+    sum(e.best_estimate) as "ESTIMATE",
+    0 as "CONFIDENCE",
+    sum(e.population_lower_confidence_limit) + 1.96*sqrt(sum(population_variance)) as "GUESS_MIN",
+    sum(e.population_upper_confidence_limit) + 1.96*sqrt(sum(population_variance)) as "GUESS_MAX",
+    sum(e.population_variance) population_variance
+  FROM
+    estimate_factors_analyses_categorized_for_add e
+  WHERE 
+    e.category = 'C'
+  GROUP BY "CATEGORY", "SURVEYTYPE", analysis_year, analysis_name, continent, region
+
+  ORDER BY "CATEGORY";
+
+
+CREATE OR REPLACE VIEW estimate_factors_analyses_categorized_totals_region_for_add AS
+  SELECT
+    analysis_name,
+    analysis_year,
+    continent,
+    region,
+    sum("ESTIMATE") "ESTIMATE",
+    1.96*sqrt(sum(population_variance)) "CONFIDENCE",
+    sum("GUESS_MIN") "GUESS_MIN",
+    sum("GUESS_MAX") "GUESS_MAX"
+  FROM estimate_factors_analyses_categorized_sums_region_for_add
+  GROUP BY analysis_name, analysis_year, continent, region;
+
+
+CREATE OR REPLACE VIEW estimate_factors_analyses_categorized_sums_continent_for_add AS
+  SELECT
+    e.category as "CATEGORY",
+    surveytype as "SURVEYTYPE",
+    analysis_year,
+    analysis_name,
+    continent,
+    sum(e.best_estimate) as "ESTIMATE",
+    1.96*sqrt(sum(e.population_variance)) as "CONFIDENCE",
+    sum(e.population_lower_confidence_limit) as "GUESS_MIN",
+    sum(e.population_upper_confidence_limit) as "GUESS_MAX",
+    sum(e.population_variance) population_variance
+  FROM
+    estimate_factors_analyses_categorized_for_add e
+  WHERE
+    e.category <> 'C'
+  GROUP BY "CATEGORY", "SURVEYTYPE", analysis_year, analysis_name, continent
+
+  UNION
+
+  SELECT
+    e.category as "CATEGORY",
+    surveytype as "SURVEYTYPE",
+    analysis_year,
+    analysis_name,
+    continent,
+    sum(e.best_estimate) as "ESTIMATE",
+    0 as "CONFIDENCE",
+    sum(e.population_lower_confidence_limit) + 1.96*sqrt(sum(population_variance)) as "GUESS_MIN",
+    sum(e.population_upper_confidence_limit) + 1.96*sqrt(sum(population_variance)) as "GUESS_MAX",
+    sum(e.population_variance) population_variance
+  FROM
+    estimate_factors_analyses_categorized_for_add e
+  WHERE 
+    e.category = 'C'
+  GROUP BY "CATEGORY", "SURVEYTYPE", analysis_year, analysis_name, continent
+
+  ORDER BY "CATEGORY";
+
+CREATE OR REPLACE VIEW estimate_factors_analyses_categorized_totals_continent_for_add AS
+  SELECT
+    analysis_name,
+    analysis_year,
+    continent,
+    sum("ESTIMATE") "ESTIMATE",
+    1.96*sqrt(sum(population_variance)) "CONFIDENCE",
+    sum("GUESS_MIN") "GUESS_MIN",
+    sum("GUESS_MAX") "GUESS_MAX"
+  FROM estimate_factors_analyses_categorized_sums_continent_for_add
+  GROUP BY analysis_name, analysis_year, continent;
+
+
+DROP VIEW IF EXISTS estimate_locator_with_geometry_add;
+CREATE VIEW estimate_locator_with_geometry_add AS
+  SELECT
+    g.id as id,
+    l.*,
+    g.geom
+  FROM survey_geometries g
+  JOIN estimate_factors f
+    ON f.survey_geometry_id = g.id
+  JOIN estimate_factors_analyses_categorized_for_add l
+    ON l.input_zone_id = f.input_zone_id;

--- a/script/calculator/20160531/1200_static_spatial_queries.sql
+++ b/script/calculator/20160531/1200_static_spatial_queries.sql
@@ -1,0 +1,116 @@
+DROP VIEW IF EXISTS estimate_locator_with_geometry CASCADE;
+CREATE VIEW estimate_locator_with_geometry AS
+ SELECT g.id,
+    l.estimate_type,
+    l.input_zone_id,
+    l.population_submission_id,
+    l.site_name,
+    l.stratum_name,
+    l.stratum_area,
+    l.completion_year,
+    l.analysis_name,
+    l.analysis_year,
+    l.age,
+    l.replacement_name,
+    l.reason_change,
+    l.citation,
+    l.short_citation,
+    l.population_estimate,
+    l.population_variance,
+    l.population_standard_error,
+    l.population_confidence_interval,
+    l.population_lower_confidence_limit,
+    l.population_upper_confidence_limit,
+    l.quality_level,
+    l.actually_seen,
+    l.lcl95,
+    l.category,
+    l.country,
+    l.region,
+    l.continent,
+    g.geom
+   FROM survey_geometries g
+     JOIN estimate_factors f ON f.survey_geometry_id = g.id
+     JOIN estimate_locator l ON l.input_zone_id = f.input_zone_id;
+
+CREATE VIEW estimate_locator_areas AS
+ SELECT e.input_zone_id,
+    e.analysis_name,
+    e.analysis_year,
+    sum(st_area(e.geom::geography, true)) / 1000000::double precision AS area_sqkm
+   FROM estimate_locator_with_geometry e
+  GROUP BY e.input_zone_id, e.analysis_name, e.analysis_year
+  ORDER BY e.input_zone_id, e.analysis_name, e.analysis_year;
+
+DROP VIEW IF EXISTS estimate_locator_with_geometry_add CASCADE;
+CREATE VIEW estimate_locator_with_geometry_add AS
+ SELECT g.id,
+    l.estimate_type,
+    l.input_zone_id,
+    l.population_submission_id,
+    l.site_name,
+    l.stratum_name,
+    l.stratum_area,
+    l.completion_year,
+    l.analysis_name,
+    l.analysis_year,
+    l.age,
+    l.replacement_name,
+    l.reason_change,
+    l.citation,
+    l.short_citation,
+    l.best_estimate as population_estimate,
+    l.best_population_variance as population_variance,
+    l.population_standard_error,
+    l.population_confidence_interval,
+    l.population_lower_confidence_limit,
+    l.population_upper_confidence_limit,
+    l.quality_level,
+    l.actually_seen,
+    l.lcl95,
+    l.category,
+    l.country,
+    l.region,
+    l.continent,
+    g.geom
+   FROM survey_geometries g
+     JOIN estimate_factors f ON f.survey_geometry_id = g.id
+     JOIN estimate_factors_analyses_categorized_for_add l ON l.input_zone_id = f.input_zone_id;
+
+CREATE VIEW estimate_locator_areas_add AS
+ SELECT e.input_zone_id,
+    e.analysis_name,
+    e.analysis_year,
+    sum(st_area(e.geom::geography, true)) / 1000000::double precision AS area_sqkm
+   FROM estimate_locator_with_geometry_add e
+  GROUP BY e.input_zone_id, e.analysis_name, e.analysis_year
+  ORDER BY e.input_zone_id, e.analysis_name, e.analysis_year;
+
+drop table if exists survey_range_intersections cascade;
+drop table if exists survey_range_intersections_add cascade;
+
+create table survey_range_intersections as
+  select analysis_name, analysis_year, region, category, reason_change, l.country, range_quality,
+    ST_Intersection(ST_MakeValid(ST_Force2D(ST_SetSRID(geom,4326))),ST_MakeValid(ST_Force2D(ST_SetSRID(range_geometry,4326))))
+  from estimate_locator_with_geometry l
+  join country_range c on ST_Intersects(ST_SetSRID(geom,4326),ST_SetSRID(range_geometry,4326))
+  where range=1;
+
+create view survey_range_intersections_add as
+  select analysis_name, analysis_year, region, category, reason_change, l.country, range_quality,
+    ST_Intersection(ST_MakeValid(ST_Force2D(ST_SetSRID(geom,4326))),ST_MakeValid(ST_Force2D(ST_SetSRID(range_geometry,4326))))
+  from estimate_locator_with_geometry_add l
+  join country_range c on ST_Intersects(ST_SetSRID(geom,4326),ST_SetSRID(range_geometry,4326))
+  where range=1;
+
+drop table if exists survey_range_intersection_metrics cascade;
+create table survey_range_intersection_metrics as
+select analysis_name, analysis_year, region, range_quality, category, reason_change, country,
+    ST_Area(st_intersection::geography,true)/1000000 area_sqkm
+  from survey_range_intersections;
+
+drop table if exists survey_range_intersection_metrics_add cascade;
+create table survey_range_intersection_metrics_add as
+select analysis_name, analysis_year, region, range_quality, category, reason_change, country,
+    ST_Area(st_intersection::geography,true)/1000000 area_sqkm
+  from survey_range_intersections_add;

--- a/script/calculator/20160531/1210_static_spatial_range_queries.sql
+++ b/script/calculator/20160531/1210_static_spatial_range_queries.sql
@@ -1,0 +1,139 @@
+update range_geometries set geometry=ST_MakeValid(geometry) where not ST_IsValid(geometry);
+
+--
+-- static geo queries
+--
+
+drop table if exists country_range cascade;
+create table country_range as 
+select 
+  c.cntryname country, g.range, g.rangequali range_quality, 
+  ST_MakeValid(ST_Multi(ST_CollectionExtract(ST_Intersection(geometry,geom),3))) range_geometry 
+from range_geometries g, country c where ST_Intersects(geometry,geom);
+create index si_country_range on country_range using gist (range_geometry);
+
+drop table if exists country_range_metrics cascade;
+create table country_range_metrics as
+select
+  'Africa'::text continent, region, country, range, range_quality, 
+  SUM(ST_Area(range_geometry::geography,true))/1000000 area_sqkm 
+from country_range 
+join country on cntryname=country 
+where range=1 
+group by region, country, range, range_quality 
+order by region, country, range, range_quality;
+
+--
+-- derived metrics
+--
+
+drop view if exists regional_range_metrics;
+create or replace view regional_range_metrics as 
+select 
+  continent, region, range, range_quality, 
+  SUM(area_sqkm) area_sqkm
+from country_range_metrics 
+group by continent, region, range, range_quality;
+
+drop view if exists continental_range_metrics;
+create or replace view continental_range_metrics as 
+select
+  continent, range, range_quality, SUM(area_sqkm) area_sqkm 
+from regional_range_metrics
+group by continent, range, range_quality;
+
+
+--
+-- Regional and continental range tables
+--
+
+drop view if exists regional_range_table;
+create or replace view regional_range_table as
+select
+  sm.analysis_name,
+  sm.analysis_year,
+  r.region,
+  m.country,
+  sum(m.area_sqkm) range_area,
+  sum(r.area_sqkm) regional_range,
+  (sum(m.area_sqkm)/sum(r.area_sqkm))*100 percent_regional_range,
+  sum(sm.area_sqkm) range_assessed,
+  (sum(sm.area_sqkm)/sum(m.area_sqkm))*100 percent_range_assessed
+from (
+  select country, sum(area_sqkm) area_sqkm 
+  from country_range_metrics group by country
+) m
+join country c on c.cntryname = m.country
+join (
+  select region, sum(area_sqkm) area_sqkm 
+  from regional_range_metrics 
+  group by region
+) r on r.region = c.region
+join (
+  select analysis_name, analysis_year, country, sum(area_sqkm) area_sqkm 
+  from survey_range_intersection_metrics 
+  group by analysis_name, analysis_year, country
+) sm on sm.country = m.country
+group by sm.analysis_name, sm.analysis_year, r.region, m.country
+order by sm.analysis_name, sm.analysis_year, r.region, m.country;
+
+drop view if exists regional_range_totals;
+create or replace view regional_range_totals as
+select
+  analysis_name,
+  analysis_year,
+  region,
+  sum(range_area) range_area,
+  regional_range regional_range,
+  sum(percent_regional_range) percent_regional_range,
+  sum(range_assessed) range_assessed,
+  (sum(range_assessed)/sum(range_area))*100 percent_range_assessed
+from
+regional_range_table
+group by analysis_name, analysis_year, region, regional_range
+order by analysis_name, analysis_year, region;
+
+drop view if exists continental_range_table;
+create or replace view continental_range_table as
+select
+  sm.analysis_name,
+  sm.analysis_year,
+  'Africa'::text continent,
+  r.region,
+  sum(m.area_sqkm) range_area,
+  sum(n.area_sqkm) continental_range,
+  (sum(m.area_sqkm)/sum(n.area_sqkm))*100 percent_continental_range,
+  sum(sm.area_sqkm) range_assessed,
+  (sum(sm.area_sqkm)/sum(m.area_sqkm))*100 percent_range_assessed
+from (
+  select region, sum(area_sqkm) area_sqkm 
+  from regional_range_metrics group by region) m
+  join region r on r.region = m.region
+  join (
+    select 'Africa'::text continent, sum(area_sqkm) area_sqkm 
+    from continental_range_metrics
+  ) n on n.continent = r.continent
+  join (
+    select analysis_name, analysis_year, region, sum(area_sqkm) area_sqkm 
+    from survey_range_intersection_metrics 
+    group by analysis_name, analysis_year, region
+  ) sm on sm.region = m.region
+group by sm.analysis_name, sm.analysis_year, n.continent, r.region
+order by sm.analysis_name, sm.analysis_year, n.continent, r.region;
+
+drop view if exists continental_range_totals;
+create or replace view continental_range_totals as
+select
+  analysis_name,
+  analysis_year,
+  continent,
+  sum(range_area) range_area,
+  sum(continental_range) continental_range,
+  sum(percent_continental_range) percent_continental_range,
+  sum(range_assessed) range_assessed,
+  (sum(range_assessed)/sum(range_area))*100 percent_range_assessed
+from
+continental_range_table
+group by analysis_name, analysis_year, continent
+order by analysis_name, analysis_year, continent;
+

--- a/script/calculator/20160531/1220_static_spatial_area_of_range.sql
+++ b/script/calculator/20160531/1220_static_spatial_area_of_range.sql
@@ -1,0 +1,190 @@
+--
+-- Area of range tables
+--
+
+drop view if exists area_of_range_extant cascade;
+create or replace view area_of_range_extant as
+select
+  c.region,
+  c.cntryname country,
+  k.known,
+  p.possible,
+  COALESCE(k.known, 0) + COALESCE(p.possible, 0) total
+from country c
+left join (
+  select
+    m.region,
+    m.country,
+    sum(area_sqkm) known
+  from country_range_metrics m
+  where range=1 and range_quality='Known'
+  group by m.region, m.country
+) k on k.country = c.cntryname
+left join (
+  select
+    m.region,
+    m.country,
+    sum(area_sqkm) possible
+  from country_range_metrics m
+  where range=1 and range_quality='Possible'
+  group by m.region, m.country
+) p on p.country = c.cntryname
+order by region, country;
+
+drop view if exists area_of_range_covered cascade;
+create or replace view area_of_range_covered as
+select
+  k.analysis_name,
+  k.analysis_year,
+  k.region,
+  k.country,
+  k.surveytype,
+  k.known,
+  p.possible,
+  COALESCE(k.known, 0) + COALESCE(p.possible, 0) total
+from (
+  select
+    m.analysis_name,
+    m.analysis_year,
+    m.country,
+    m.region,
+    t.surveytype,
+    sum(area_sqkm) known
+  from survey_range_intersection_metrics m
+  join surveytypes t on t.category = m.category
+  where range_quality='Known'
+  group by m.analysis_name, m.analysis_year, m.country, m.region, t.surveytype
+) k
+left join (
+  select
+    m.analysis_name,
+    m.analysis_year,
+    m.country,
+    m.region,
+    t.surveytype,
+    sum(area_sqkm) possible
+  from survey_range_intersection_metrics m
+  join surveytypes t on t.category = m.category
+  where range_quality='Possible'
+  group by m.analysis_name, m.analysis_year, m.country, m.region, t.surveytype
+) p on k.analysis_name = p.analysis_name and k.analysis_year = p.analysis_year and 
+  k.country = p.country and k.surveytype = p.surveytype
+order by analysis_name, analysis_year, region, country, surveytype;
+
+drop view if exists area_of_range_covered_subtotals cascade;
+create or replace view area_of_range_covered_subtotals as
+select
+  analysis_name,
+  analysis_year,
+  region,
+  country,
+  sum(known) known,
+  sum(possible) possible,
+  sum(total) total
+from area_of_range_covered
+group by analysis_name, analysis_year, region, country
+order by analysis_name, analysis_year, region, country;
+
+drop view if exists area_of_range_covered_unassessed cascade;
+create or replace view area_of_range_covered_unassessed as
+select
+  n.analysis_name,
+  n.analysis_year,
+  x.region,
+  x.country,
+  x.known - n.known known,
+  x.possible - n.possible possible,
+  x.total - n.total total
+from area_of_range_extant x join
+area_of_range_covered_subtotals n on x.country = n.country
+order by n.analysis_name, n.analysis_year, x.region, x.country;
+
+drop view if exists area_of_range_covered_totals cascade;
+create view area_of_range_covered_totals as
+select
+  analysis_name, analysis_year,
+  region,
+  country,
+  sum(known) known,
+  sum(possible) possible,
+  sum(total) total
+from (
+  select * from area_of_range_covered_subtotals
+  union
+  select * from area_of_range_covered_unassessed
+) t
+group by analysis_name, analysis_year, region, country
+order by analysis_name, analysis_year, region, country;
+
+drop view if exists regional_area_of_range_covered;
+create or replace view regional_area_of_range_covered as
+select
+  analysis_name, analysis_year,
+  region,
+  surveytype,
+  sum(known) known,
+  sum(possible) possible,
+  sum(total) total
+from
+  area_of_range_covered
+group by analysis_name, analysis_year, region, surveytype
+order by analysis_name, analysis_year, region, surveytype;
+
+drop view if exists regional_area_of_range_covered_unassessed;
+create or replace view regional_area_of_range_covered_unassessed as
+select
+  analysis_name, analysis_year,
+  region,
+  sum(known) known,
+  sum(possible) possible,
+  sum(total) total
+from
+  area_of_range_covered_unassessed
+group by analysis_name, analysis_year, region
+order by analysis_name, analysis_year, region;
+
+drop view if exists regional_area_of_range_covered_totals;
+create or replace view regional_area_of_range_covered_totals as
+select
+  analysis_name, analysis_year,
+  region,
+  sum(known) known,
+  sum(possible) possible,
+  sum(total) total
+from area_of_range_covered_totals
+group by analysis_name, analysis_year, region
+order by analysis_name, analysis_year, region;
+
+drop view if exists continental_area_of_range_covered;
+create or replace view continental_area_of_range_covered as
+select
+  analysis_name, analysis_year,
+  surveytype,
+  sum(known) known,
+  sum(possible) possible,
+  sum(total) total
+from
+area_of_range_covered
+group by analysis_name, analysis_year, surveytype
+order by analysis_name, analysis_year, surveytype;
+
+drop view if exists continental_area_of_range_covered_unassessed;
+create or replace view continental_area_of_range_covered_unassessed as
+select
+  analysis_name, analysis_year,
+  sum(known) known,
+  sum(possible) possible,
+  sum(total) total
+from area_of_range_covered_unassessed
+group by analysis_name, analysis_year;
+
+drop view if exists continental_area_of_range_covered_totals;
+create or replace view continental_area_of_range_covered_totals as
+select
+  analysis_name, analysis_year,
+  sum(known) known,
+  sum(possible) possible,
+  sum(total) total
+from area_of_range_covered_totals
+group by analysis_name, analysis_year;
+

--- a/script/calculator/20160531/2000_new_change_interpreters.sql
+++ b/script/calculator/20160531/2000_new_change_interpreters.sql
@@ -1,0 +1,38 @@
+-- Dissected from/to information
+
+drop view if exists changed_strata cascade;
+create or replace view changed_strata as
+select distinct
+  analysis_name,
+  reason_change,
+  replaced_stratum,
+  new_stratum
+from (
+  select
+    q.analysis_name,
+    CAST(CASE
+      WHEN q.reason_change = '-' and a.age > 10 THEN 'DD'
+      ELSE q.reason_change
+    END AS varchar(255)) reason_change,
+    q.replaced_stratum,
+    q.new_stratum
+    from (
+      select distinct
+        changes.analysis_name,
+        changes.reason_change,
+        unnest(regexp_split_to_array(changes.new_strata::text, ','::text)) AS new_stratum,
+        unnest(regexp_split_to_array(changes.replaced_strata::text, ','::text)) AS replaced_stratum
+      from changes
+    ) q
+  left join estimate_factors_analyses a
+    on replaced_stratum = a.input_zone_id and q.analysis_name = a.analysis_name
+  where
+    q.new_stratum IS NOT NULL AND q.new_stratum != ''::text
+  order by
+    q.analysis_name,
+    q.reason_change,
+    q.replaced_stratum,
+    q.new_stratum
+) w
+where w.reason_change != '-';
+

--- a/script/calculator/20160531/2100_country_change_interpreters.sql
+++ b/script/calculator/20160531/2100_country_change_interpreters.sql
@@ -1,0 +1,387 @@
+-- Country change interpeters
+
+drop view if exists i_dpps_sums_country_category cascade;
+create or replace view i_dpps_sums_country_category as
+select
+  e.analysis_name,
+  e.analysis_year,
+  e.continent,
+  e.region,
+  e.country,
+  e.category,
+  round(sum(definite)) definite,
+  round(sum(probable)) probable,
+  round(sum(possible)) possible,
+  round(sum(speculative)) speculative
+from estimate_locator e
+  join estimate_dpps d on e.input_zone_id = d.input_zone_id
+    and e.analysis_name = d.analysis_name
+    and e.analysis_year = d.analysis_year
+  where e.category='A'
+group by
+  e.analysis_name,
+  e.analysis_year,
+  e.continent,
+  e.region,
+  e.country,
+  e.category
+
+UNION
+
+select
+  e.analysis_name,
+  e.analysis_year,
+  e.continent,
+  e.region,
+  e.country,
+  e.category,
+  CASE WHEN SUM(actually_seen) > (SUM(e.population_estimate)-SQRT(SUM(population_variance))*1.96)
+  THEN SUM(actually_seen)
+  ELSE ROUND(SUM(e.population_estimate) - SQRT(SUM(population_variance))*1.96)
+  END definite,
+  round(sqrt(sum(population_variance))*1.96) probable,
+  round(sqrt(sum(population_variance))*1.96) possible,
+  round(sum(speculative)) speculative
+from estimate_locator e
+  join estimate_dpps d on e.input_zone_id = d.input_zone_id
+    and e.analysis_name = d.analysis_name
+    and e.analysis_year = d.analysis_year
+  where e.category='B'
+group by
+  e.analysis_name,
+  e.analysis_year,
+  e.continent,
+  e.region,
+  e.country,
+  e.category
+
+UNION
+
+select
+  e.analysis_name,
+  e.analysis_year,
+  e.continent,
+  e.region,
+  e.country,
+  e.category,
+  round(sum(definite)) definite,
+  round(sum(probable)-sum(definite)) probable,
+  round(sqrt(sum(population_variance))*1.96) possible,
+  round(sum(speculative)) speculative
+from estimate_locator e
+  join estimate_dpps d on e.input_zone_id = d.input_zone_id
+    and e.analysis_name = d.analysis_name
+    and e.analysis_year = d.analysis_year
+  where e.category='C'
+group by
+  e.analysis_name,
+  e.analysis_year,
+  e.continent,
+  e.region,
+  e.country,
+  e.category
+
+UNION
+
+select
+  e.analysis_name,
+  e.analysis_year,
+  e.continent,
+  e.region,
+  e.country,
+  e.category,
+  round(sum(definite)) definite,
+  round(sum(probable)) probable,
+  round(sum(possible)) possible,
+  round(sum(speculative)) speculative
+from estimate_locator e
+  join estimate_dpps d on e.input_zone_id = d.input_zone_id
+    and e.analysis_name = d.analysis_name
+    and e.analysis_year = d.analysis_year
+  where e.category='D'
+group by
+  e.analysis_name,
+  e.analysis_year,
+  e.continent,
+  e.region,
+  e.country,
+  e.category
+
+UNION
+
+select
+  e.analysis_name,
+  e.analysis_year,
+  e.continent,
+  e.region,
+  e.country,
+  e.category,
+  round(sum(definite)) definite,
+  round(sum(probable)) probable,
+  round(sum(possible)) possible,
+  round(sum(speculative)) speculative
+from estimate_locator e
+  join estimate_dpps d on e.input_zone_id = d.input_zone_id
+    and e.analysis_name = d.analysis_name
+    and e.analysis_year = d.analysis_year
+  where e.category='E'
+group by
+  e.analysis_name,
+  e.analysis_year,
+  e.continent,
+  e.region,
+  e.country,
+  e.category
+
+order by
+  analysis_name,
+  analysis_year,
+  continent,
+  region,
+  country,
+  category
+;
+
+--- Statify the pooled base query; it's too slow to run in realtime
+drop table if exists dpps_sums_country_category cascade;
+create table dpps_sums_country_category as select * from i_dpps_sums_country_category;
+
+drop view if exists dpps_sums_country;
+create view dpps_sums_country as
+select
+  analysis_name,
+  analysis_year,
+  continent,
+  region,
+  country,
+  sum(definite) definite,
+  sum(probable) probable,
+  sum(possible) possible,
+  sum(speculative) speculative
+from
+  dpps_sums_country_category
+group by
+  analysis_name,
+  analysis_year,
+  continent,
+  region,
+  country
+order by
+  analysis_name,
+  analysis_year,
+  continent,
+  region,
+  country;
+
+drop view if exists actual_diff_country;
+create view actual_diff_country as
+select
+  y.analysis_name,
+  y.analysis_year,
+  a.continent,
+  a.region,
+  a.country,
+  a.definite-o.definite actual_dif_def,
+  a.probable-o.probable actual_dif_prob,
+  a.possible-o.possible actual_dif_poss,
+  a.speculative-o.speculative actual_dif_spec
+from analyses y
+  join dpps_sums_country a
+    on a.analysis_name=y.analysis_name and a.analysis_year=y.analysis_year
+  join dpps_sums_country o
+    on o.analysis_name=y.analysis_name and o.analysis_year=y.comparison_year
+    and a.country = o.country
+order by
+  y.analysis_name,
+  y.analysis_year,
+  a.continent,
+  a.region,
+  a.country;
+
+drop view if exists i_dpps_sums_country_category_reason;
+create view i_dpps_sums_country_category_reason as
+select * from (
+  select
+    d.analysis_name,
+    d.analysis_year,
+    continent,
+    region,
+    country,
+    d.category,
+    reason_change,
+    sum(definite) definite,
+    sum(probable) probable,
+    sum(possible) possible,
+    sum(speculative) speculative
+  from
+    analyses y
+    join estimate_locator e
+      on e.analysis_name=y.analysis_name and e.analysis_year=y.analysis_year
+        and e.reason_change != '-'
+    join estimate_dpps d on e.input_zone_id = d.input_zone_id
+      and e.analysis_name = d.analysis_name
+      and e.analysis_year = d.analysis_year
+  group by
+    d.analysis_name,
+    d.analysis_year,
+    continent,
+    region,
+    country,
+    d.category,
+    reason_change
+  union
+  select
+    analysis_name,
+    analysis_year,
+    continent,
+    region,
+    country,
+    category,
+    reason_change,
+    sum(-1*definite) definite,
+    sum(-1*probable) probable,
+    sum(-1*possible) possible,
+    sum(-1*speculative) speculative
+  from
+    (
+      select distinct
+        d.analysis_name,
+        e.analysis_year,
+        continent,
+        region,
+        country,
+        d.category,
+        c.reason_change,
+        definite,
+        probable,
+        possible,
+        speculative
+      from
+        analyses y
+        join estimate_locator e
+          on e.analysis_name=y.analysis_name and e.analysis_year=y.analysis_year
+            and e.reason_change != '-'
+        join changed_strata c on e.input_zone_id = c.new_stratum
+          and e.analysis_name = c.analysis_name
+        join estimate_dpps d on d.input_zone_id = c.replaced_stratum
+          and e.analysis_name = d.analysis_name
+          and d.analysis_year = y.comparison_year
+    ) s
+  group by
+    analysis_name,
+    analysis_year,
+    continent,
+    region,
+    country,
+    category,
+    reason_change
+) s
+order by
+  analysis_name,
+  analysis_year,
+  continent,
+  region,
+  country,
+  category,
+  reason_change
+;
+
+--- Statify the reason base query; it's too slow to run in realtime
+drop table if exists dpps_sums_country_category_reason cascade;
+create table dpps_sums_country_category_reason as select * from i_dpps_sums_country_category_reason;
+
+drop view if exists fractional_causes_of_change_by_country;
+create view fractional_causes_of_change_by_country as
+select
+  g.analysis_name,
+  g.analysis_year,
+  g.country,
+  "CauseofChange",
+  sum(definite) as definite,
+  sum(probable) as probable,
+  sum(possible) as possible,
+  sum(speculative) as specul
+from dpps_sums_country_category_reason g
+join aed2007."CausesOfChange" on
+  reason_change="ChangeCODE"
+group by g.analysis_name, g.analysis_year, g.country, display_order, "CauseofChange"
+order by g.analysis_name, g.analysis_year, g.country, display_order, "CauseofChange";
+
+drop view if exists causes_of_change_by_country;
+create view causes_of_change_by_country as
+select
+  analysis_name,
+  analysis_year,
+  country,
+  "CauseofChange",
+  round(definite) definite,
+  round(probable) probable,
+  round(possible) possible,
+  round(specul) specul
+from fractional_causes_of_change_by_country;
+
+drop view if exists causes_of_change_sums_by_country;
+create view causes_of_change_sums_by_country as
+select
+  analysis_name,
+  analysis_year,
+  country,
+  round(sum(definite)) definite,
+  round(sum(probable)) probable,
+  round(sum(possible)) possible,
+  round(sum(specul)) specul
+from
+  fractional_causes_of_change_by_country
+group by analysis_name,analysis_year,country;
+
+drop view if exists country_factors;
+create or replace view country_factors as
+select
+  c.analysis_name,
+  c.analysis_year,
+  c.country,
+  (actual_dif_def / CASE WHEN definite=0 THEN 1 ELSE definite END) def_factor,
+  (actual_dif_prob / CASE WHEN probable=0 THEN 1 ELSE probable END) prob_factor,
+  (actual_dif_poss / CASE WHEN possible=0 THEN 1 ELSE possible END) poss_factor,
+  (actual_dif_spec / CASE WHEN specul=0 THEN 1 ELSE specul END) spec_factor
+from causes_of_change_sums_by_country c
+join actual_diff_country a
+  on a.analysis_name = c.analysis_name
+  and a.analysis_year = c.analysis_year
+  and a.country= c.country
+;
+
+drop view if exists causes_of_change_by_country_scaled;
+create view causes_of_change_by_country_scaled as
+select
+  c.analysis_name,
+  c.analysis_year,
+  c.country,
+  "CauseofChange",
+  round(definite * def_factor) definite,
+  round(probable * prob_factor) probable,
+  round(possible * poss_factor) possible,
+  round(specul * spec_factor) specul
+from fractional_causes_of_change_by_country c
+join country_factors a
+  on a.analysis_name = c.analysis_name
+  and a.analysis_year = c.analysis_year
+  and a.country= c.country
+;
+
+drop view if exists causes_of_change_sums_by_country_scaled;
+create or replace view causes_of_change_sums_by_country_scaled as
+select
+  c.analysis_name,
+  c.analysis_year,
+  c.country,
+  definite * def_factor definite,
+  probable * prob_factor probable,
+  possible * poss_factor possible,
+  specul * spec_factor specul
+from causes_of_change_sums_by_country c
+join country_factors a
+  on a.analysis_name = c.analysis_name
+  and a.analysis_year = c.analysis_year
+  and a.country= c.country
+;

--- a/script/calculator/20160531/2200_regional_change_interpreters.sql
+++ b/script/calculator/20160531/2200_regional_change_interpreters.sql
@@ -1,0 +1,365 @@
+-- Regional change interpeters
+
+drop view if exists i_dpps_sums_region_category cascade;
+create or replace view i_dpps_sums_region_category as
+select
+  e.analysis_name,
+  e.analysis_year,
+  e.continent,
+  e.region,
+  e.category,
+  round(sum(definite)) definite,
+  round(sum(probable)) probable,
+  round(sum(possible)) possible,
+  round(sum(speculative)) speculative
+from estimate_locator e
+  join estimate_dpps d on e.input_zone_id = d.input_zone_id
+    and e.analysis_name = d.analysis_name
+    and e.analysis_year = d.analysis_year
+  where e.category='A'
+group by
+  e.analysis_name,
+  e.analysis_year,
+  e.continent,
+  e.region,
+  e.category
+
+UNION
+
+select
+  e.analysis_name,
+  e.analysis_year,
+  e.continent,
+  e.region,
+  e.category,
+  CASE WHEN SUM(actually_seen) > (SUM(e.population_estimate)-SQRT(SUM(population_variance))*1.96)
+  THEN SUM(actually_seen)
+  ELSE ROUND(SUM(e.population_estimate) - SQRT(SUM(population_variance))*1.96)
+  END definite,
+  round(sqrt(sum(population_variance))*1.96) probable,
+  round(sqrt(sum(population_variance))*1.96) possible,
+  round(sum(speculative)) speculative
+from estimate_locator e
+  join estimate_dpps d on e.input_zone_id = d.input_zone_id
+    and e.analysis_name = d.analysis_name
+    and e.analysis_year = d.analysis_year
+  where e.category='B'
+group by
+  e.analysis_name,
+  e.analysis_year,
+  e.continent,
+  e.region,
+  e.category
+
+UNION
+
+select
+  e.analysis_name,
+  e.analysis_year,
+  e.continent,
+  e.region,
+  e.category,
+  round(sum(definite)) definite,
+  round(sum(probable)-sum(definite)) probable,
+  round(sqrt(sum(population_variance))*1.96) possible,
+  round(sum(speculative)) speculative
+from estimate_locator e
+  join estimate_dpps d on e.input_zone_id = d.input_zone_id
+    and e.analysis_name = d.analysis_name
+    and e.analysis_year = d.analysis_year
+  where e.category='C'
+group by
+  e.analysis_name,
+  e.analysis_year,
+  e.continent,
+  e.region,
+  e.category
+
+UNION
+
+select
+  e.analysis_name,
+  e.analysis_year,
+  e.continent,
+  e.region,
+  e.category,
+  round(sum(definite)) definite,
+  round(sum(probable)) probable,
+  round(sum(possible)) possible,
+  round(sum(speculative)) speculative
+from estimate_locator e
+  join estimate_dpps d on e.input_zone_id = d.input_zone_id
+    and e.analysis_name = d.analysis_name
+    and e.analysis_year = d.analysis_year
+  where e.category='D'
+group by
+  e.analysis_name,
+  e.analysis_year,
+  e.continent,
+  e.region,
+  e.category
+
+UNION
+
+select
+  e.analysis_name,
+  e.analysis_year,
+  e.continent,
+  e.region,
+  e.category,
+  round(sum(definite)) definite,
+  round(sum(probable)) probable,
+  round(sum(possible)) possible,
+  round(sum(speculative)) speculative
+from estimate_locator e
+  join estimate_dpps d on e.input_zone_id = d.input_zone_id
+    and e.analysis_name = d.analysis_name
+    and e.analysis_year = d.analysis_year
+  where e.category='E'
+group by
+  e.analysis_name,
+  e.analysis_year,
+  e.continent,
+  e.region,
+  e.category
+
+order by
+  analysis_name,
+  analysis_year,
+  continent,
+  region,
+  category
+;
+
+--- Statify the pooled base query; it's too slow to run in realtime
+drop table if exists dpps_sums_region_category cascade;
+create table dpps_sums_region_category as select * from i_dpps_sums_region_category;
+
+drop view if exists dpps_sums_region;
+create view dpps_sums_region as
+select
+  analysis_name,
+  analysis_year,
+  continent,
+  region,
+  sum(definite) definite,
+  sum(probable) probable,
+  sum(possible) possible,
+  sum(speculative) speculative
+from
+  dpps_sums_region_category
+group by
+  analysis_name,
+  analysis_year,
+  continent,
+  region
+order by
+  analysis_name,
+  analysis_year,
+  continent,
+  region;
+
+drop view if exists actual_diff_region;
+create view actual_diff_region as
+select
+  y.analysis_name,
+  y.analysis_year,
+  a.continent,
+  a.region,
+  a.definite-o.definite actual_dif_def,
+  a.probable-o.probable actual_dif_prob,
+  a.possible-o.possible actual_dif_poss,
+  a.speculative-o.speculative actual_dif_spec
+from analyses y
+  join dpps_sums_region a
+    on a.analysis_name=y.analysis_name and a.analysis_year=y.analysis_year
+  join dpps_sums_region o
+    on o.analysis_name=y.analysis_name and o.analysis_year=y.comparison_year
+    and a.region = o.region
+order by
+  y.analysis_name,
+  y.analysis_year,
+  a.continent,
+  a.region;
+
+drop view if exists i_dpps_sums_region_category_reason;
+create view i_dpps_sums_region_category_reason as
+select * from (
+  select
+    d.analysis_name,
+    d.analysis_year,
+    continent,
+    region,
+    d.category,
+    reason_change,
+    sum(definite) definite,
+    sum(probable) probable,
+    sum(possible) possible,
+    sum(speculative) speculative
+  from
+    analyses y
+    join estimate_locator e
+      on e.analysis_name=y.analysis_name and e.analysis_year=y.analysis_year
+        and e.reason_change != '-'
+    join estimate_dpps d on e.input_zone_id = d.input_zone_id
+      and e.analysis_name = d.analysis_name
+      and e.analysis_year = d.analysis_year
+  group by
+    d.analysis_name,
+    d.analysis_year,
+    continent,
+    region,
+    d.category,
+    reason_change
+  union
+  select
+    analysis_name,
+    analysis_year,
+    continent,
+    region,
+    category,
+    reason_change,
+    sum(-1*definite) definite,
+    sum(-1*probable) probable,
+    sum(-1*possible) possible,
+    sum(-1*speculative) speculative
+  from
+    (
+      select distinct
+        d.analysis_name,
+        e.analysis_year,
+        continent,
+        region,
+        d.category,
+        c.reason_change,
+        definite,
+        probable,
+        possible,
+        speculative
+      from
+        analyses y
+        join estimate_locator e
+          on e.analysis_name=y.analysis_name and e.analysis_year=y.analysis_year
+            and e.reason_change != '-'
+        join changed_strata c on e.input_zone_id = c.new_stratum
+          and e.analysis_name = c.analysis_name
+        join estimate_dpps d on d.input_zone_id = c.replaced_stratum
+          and e.analysis_name = d.analysis_name
+          and d.analysis_year = y.comparison_year
+    ) s
+  group by
+    analysis_name,
+    analysis_year,
+    continent,
+    region,
+    category,
+    reason_change
+) s
+order by
+  analysis_name,
+  analysis_year,
+  continent,
+  region,
+  category,
+  reason_change
+;
+
+--- Statify the reason base query; it's too slow to run in realtime
+drop table if exists dpps_sums_region_category_reason cascade;
+create table dpps_sums_region_category_reason as select * from i_dpps_sums_region_category_reason;
+
+drop view if exists fractional_causes_of_change_by_region;
+create view fractional_causes_of_change_by_region as
+select
+  g.analysis_name,
+  g.analysis_year,
+  g.region,
+  "CauseofChange",
+  sum(definite) as definite,
+  sum(probable) as probable,
+  sum(possible) as possible,
+  sum(speculative) as specul
+from dpps_sums_region_category_reason g
+join aed2007."CausesOfChange" on
+  reason_change="ChangeCODE"
+group by g.analysis_name, g.analysis_year, g.region, display_order, "CauseofChange"
+order by g.analysis_name, g.analysis_year, g.region, display_order, "CauseofChange";
+
+drop view if exists causes_of_change_by_region;
+create view causes_of_change_by_region as
+select
+  analysis_name,
+  analysis_year,
+  region,
+  "CauseofChange",
+  round(definite) definite,
+  round(probable) probable,
+  round(possible) possible,
+  round(specul) specul
+from fractional_causes_of_change_by_region;
+
+drop view if exists causes_of_change_sums_by_region;
+create view causes_of_change_sums_by_region as
+select
+  analysis_name,
+  analysis_year,
+  region,
+  round(sum(definite)) definite,
+  round(sum(probable)) probable,
+  round(sum(possible)) possible,
+  round(sum(specul)) specul
+from
+  fractional_causes_of_change_by_region
+group by analysis_name,analysis_year,region;
+
+drop view if exists region_factors;
+create or replace view region_factors as
+select
+  c.analysis_name,
+  c.analysis_year,
+  c.region,
+  (actual_dif_def / CASE WHEN definite=0 THEN 1 ELSE definite END) def_factor,
+  (actual_dif_prob / CASE WHEN probable=0 THEN 1 ELSE probable END) prob_factor,
+  (actual_dif_poss / CASE WHEN possible=0 THEN 1 ELSE possible END) poss_factor,
+  (actual_dif_spec / CASE WHEN specul=0 THEN 1 ELSE specul END) spec_factor
+from causes_of_change_sums_by_region c
+join actual_diff_region a
+  on a.analysis_name = c.analysis_name
+  and a.analysis_year = c.analysis_year
+  and a.region = c.region
+;
+
+drop view if exists causes_of_change_by_region_scaled;
+create view causes_of_change_by_region_scaled as
+select
+  c.analysis_name,
+  c.analysis_year,
+  c.region,
+  "CauseofChange",
+  round(definite * def_factor) definite,
+  round(probable * prob_factor) probable,
+  round(possible * poss_factor) possible,
+  round(specul * spec_factor) specul
+from fractional_causes_of_change_by_region c
+join region_factors a
+  on a.analysis_name = c.analysis_name
+  and a.analysis_year = c.analysis_year
+  and a.region = c.region
+;
+
+drop view if exists causes_of_change_sums_by_region_scaled;
+create or replace view causes_of_change_sums_by_region_scaled as
+select
+  c.analysis_name,
+  c.analysis_year,
+  c.region,
+  definite * def_factor definite,
+  probable * prob_factor probable,
+  possible * poss_factor possible,
+  specul * spec_factor specul
+from causes_of_change_sums_by_region c
+join region_factors a
+  on a.analysis_name = c.analysis_name
+  and a.analysis_year = c.analysis_year
+  and a.region = c.region
+;

--- a/script/calculator/20160531/2300_continental_change_interpreters.sql
+++ b/script/calculator/20160531/2300_continental_change_interpreters.sql
@@ -1,0 +1,343 @@
+-- Continental change interpeters
+
+drop view if exists i_dpps_sums_continent_category cascade;
+create or replace view i_dpps_sums_continent_category as
+select
+  e.analysis_name,
+  e.analysis_year,
+  e.continent,
+  e.category,
+  round(sum(definite)) definite,
+  round(sum(probable)) probable,
+  round(sum(possible)) possible,
+  round(sum(speculative)) speculative
+from estimate_locator e
+  join estimate_dpps d on e.input_zone_id = d.input_zone_id
+    and e.analysis_name = d.analysis_name
+    and e.analysis_year = d.analysis_year
+  where e.category='A'
+group by
+  e.analysis_name,
+  e.analysis_year,
+  e.continent,
+  e.category
+
+UNION
+
+select
+  e.analysis_name,
+  e.analysis_year,
+  e.continent,
+  e.category,
+  CASE WHEN SUM(actually_seen) > (SUM(e.population_estimate)-SQRT(SUM(population_variance))*1.96)
+  THEN SUM(actually_seen)
+  ELSE ROUND(SUM(e.population_estimate) - SQRT(SUM(population_variance))*1.96)
+  END definite,
+  round(sqrt(sum(population_variance))*1.96) probable,
+  round(sqrt(sum(population_variance))*1.96) possible,
+  round(sum(speculative)) speculative
+from estimate_locator e
+  join estimate_dpps d on e.input_zone_id = d.input_zone_id
+    and e.analysis_name = d.analysis_name
+    and e.analysis_year = d.analysis_year
+  where e.category='B'
+group by
+  e.analysis_name,
+  e.analysis_year,
+  e.continent,
+  e.category
+
+UNION
+
+select
+  e.analysis_name,
+  e.analysis_year,
+  e.continent,
+  e.category,
+  round(sum(definite)) definite,
+  round(sum(probable)-sum(definite)) probable,
+  round(sqrt(sum(population_variance))*1.96) possible,
+  round(sum(speculative)) speculative
+from estimate_locator e
+  join estimate_dpps d on e.input_zone_id = d.input_zone_id
+    and e.analysis_name = d.analysis_name
+    and e.analysis_year = d.analysis_year
+  where e.category='C'
+group by
+  e.analysis_name,
+  e.analysis_year,
+  e.continent,
+  e.category
+
+UNION
+
+select
+  e.analysis_name,
+  e.analysis_year,
+  e.continent,
+  e.category,
+  round(sum(definite)) definite,
+  round(sum(probable)) probable,
+  round(sum(possible)) possible,
+  round(sum(speculative)) speculative
+from estimate_locator e
+  join estimate_dpps d on e.input_zone_id = d.input_zone_id
+    and e.analysis_name = d.analysis_name
+    and e.analysis_year = d.analysis_year
+  where e.category='D'
+group by
+  e.analysis_name,
+  e.analysis_year,
+  e.continent,
+  e.category
+
+UNION
+
+select
+  e.analysis_name,
+  e.analysis_year,
+  e.continent,
+  e.category,
+  round(sum(definite)) definite,
+  round(sum(probable)) probable,
+  round(sum(possible)) possible,
+  round(sum(speculative)) speculative
+from estimate_locator e
+  join estimate_dpps d on e.input_zone_id = d.input_zone_id
+    and e.analysis_name = d.analysis_name
+    and e.analysis_year = d.analysis_year
+  where e.category='E'
+group by
+  e.analysis_name,
+  e.analysis_year,
+  e.continent,
+  e.category
+
+order by
+  analysis_name,
+  analysis_year,
+  continent,
+  category
+;
+
+--- Statify the pooled base query; it's too slow to run in realtime
+drop table if exists dpps_sums_continent_category cascade;
+create table dpps_sums_continent_category as select * from i_dpps_sums_continent_category;
+
+drop view if exists dpps_sums_continent;
+create view dpps_sums_continent as
+select
+  analysis_name,
+  analysis_year,
+  continent,
+  sum(definite) definite,
+  sum(probable) probable,
+  sum(possible) possible,
+  sum(speculative) speculative
+from
+  dpps_sums_continent_category
+group by
+  analysis_name,
+  analysis_year,
+  continent
+order by
+  analysis_name,
+  analysis_year,
+  continent;
+
+drop view if exists actual_diff_continent;
+create view actual_diff_continent as
+select
+  y.analysis_name,
+  y.analysis_year,
+  a.continent,
+  a.definite-o.definite actual_dif_def,
+  a.probable-o.probable actual_dif_prob,
+  a.possible-o.possible actual_dif_poss,
+  a.speculative-o.speculative actual_dif_spec
+from analyses y
+  join dpps_sums_continent a
+    on a.analysis_name=y.analysis_name and a.analysis_year=y.analysis_year
+  join dpps_sums_continent o
+    on o.analysis_name=y.analysis_name and o.analysis_year=y.comparison_year
+    and a.continent = o.continent
+order by
+  y.analysis_name,
+  y.analysis_year,
+  a.continent;
+
+drop view if exists i_dpps_sums_continent_category_reason;
+create view i_dpps_sums_continent_category_reason as
+select * from (
+  select
+    d.analysis_name,
+    d.analysis_year,
+    continent,
+    d.category,
+    reason_change,
+    sum(definite) definite,
+    sum(probable) probable,
+    sum(possible) possible,
+    sum(speculative) speculative
+  from
+    analyses y
+    join estimate_locator e
+      on e.analysis_name=y.analysis_name and e.analysis_year=y.analysis_year
+        and e.reason_change != '-'
+    join estimate_dpps d on e.input_zone_id = d.input_zone_id
+      and e.analysis_name = d.analysis_name
+      and e.analysis_year = d.analysis_year
+  group by
+    d.analysis_name,
+    d.analysis_year,
+    continent,
+    d.category,
+    reason_change
+  union
+  select
+    analysis_name,
+    analysis_year,
+    continent,
+    category,
+    reason_change,
+    sum(-1*definite) definite,
+    sum(-1*probable) probable,
+    sum(-1*possible) possible,
+    sum(-1*speculative) speculative
+  from
+    (
+      select distinct
+        d.analysis_name,
+        e.analysis_year,
+        continent,
+        d.category,
+        c.reason_change,
+        definite,
+        probable,
+        possible,
+        speculative
+      from
+        analyses y
+        join estimate_locator e
+          on e.analysis_name=y.analysis_name and e.analysis_year=y.analysis_year
+            and e.reason_change != '-'
+        join changed_strata c on e.input_zone_id = c.new_stratum
+          and e.analysis_name = c.analysis_name
+        join estimate_dpps d on d.input_zone_id = c.replaced_stratum
+          and e.analysis_name = d.analysis_name
+          and d.analysis_year = y.comparison_year
+    ) s
+  group by
+    analysis_name,
+    analysis_year,
+    continent,
+    category,
+    reason_change
+) s
+order by
+  analysis_name,
+  analysis_year,
+  continent,
+  category,
+  reason_change
+;
+
+--- Statify the reason base query; it's too slow to run in realtime
+drop table if exists dpps_sums_continent_category_reason cascade;
+create table dpps_sums_continent_category_reason as select * from i_dpps_sums_continent_category_reason;
+
+drop view if exists fractional_causes_of_change_by_continent cascade;
+create view fractional_causes_of_change_by_continent as
+select
+  g.analysis_name,
+  g.analysis_year,
+  g.continent,
+  "CauseofChange",
+  sum(definite) as definite,
+  sum(probable) as probable,
+  sum(possible) as possible,
+  sum(speculative) as specul
+from dpps_sums_continent_category_reason g
+join aed2007."CausesOfChange" on
+  reason_change="ChangeCODE"
+group by g.analysis_name, g.analysis_year, g.continent, display_order, "CauseofChange"
+order by g.analysis_name, g.analysis_year, g.continent, display_order, "CauseofChange";
+
+drop view if exists causes_of_change_by_continent;
+create view causes_of_change_by_continent as
+select
+  analysis_name,
+  analysis_year,
+  continent,
+  "CauseofChange",
+  round(definite) definite,
+  round(probable) probable,
+  round(possible) possible,
+  round(specul) specul
+from fractional_causes_of_change_by_continent;
+
+drop view if exists causes_of_change_sums_by_continent;
+create view causes_of_change_sums_by_continent as
+select
+  analysis_name,
+  analysis_year,
+  continent,
+  round(sum(definite)) definite,
+  round(sum(probable)) probable,
+  round(sum(possible)) possible,
+  round(sum(specul)) specul
+from
+  fractional_causes_of_change_by_continent
+group by analysis_name,analysis_year,continent;
+
+drop view if exists continent_factors;
+create or replace view continent_factors as
+select
+  c.analysis_name,
+  c.analysis_year,
+  c.continent,
+  (actual_dif_def / CASE WHEN definite=0 THEN 1 ELSE definite END) def_factor,
+  (actual_dif_prob / CASE WHEN probable=0 THEN 1 ELSE probable END) prob_factor,
+  (actual_dif_poss / CASE WHEN possible=0 THEN 1 ELSE possible END) poss_factor,
+  (actual_dif_spec / CASE WHEN specul=0 THEN 1 ELSE specul END) spec_factor
+from causes_of_change_sums_by_continent c
+join actual_diff_continent a
+  on a.analysis_name = c.analysis_name
+  and a.analysis_year = c.analysis_year
+  and a.continent = c.continent
+;
+
+drop view if exists causes_of_change_by_continent_scaled;
+create view causes_of_change_by_continent_scaled as
+select
+  c.analysis_name,
+  c.analysis_year,
+  c.continent,
+  "CauseofChange",
+  round(definite * def_factor) definite,
+  round(probable * prob_factor) probable,
+  round(possible * poss_factor) possible,
+  round(specul * spec_factor) specul
+from fractional_causes_of_change_by_continent c
+join continent_factors a
+  on a.analysis_name = c.analysis_name
+  and a.analysis_year = c.analysis_year
+  and a.continent = c.continent
+;
+
+drop view if exists causes_of_change_sums_by_continent_scaled;
+create or replace view causes_of_change_sums_by_continent_scaled as
+select
+  c.analysis_name,
+  c.analysis_year,
+  c.continent,
+  definite * def_factor definite,
+  probable * prob_factor probable,
+  possible * poss_factor possible,
+  specul * spec_factor specul
+from causes_of_change_sums_by_continent c
+join continent_factors a
+  on a.analysis_name = c.analysis_name
+  and a.analysis_year = c.analysis_year
+  and a.continent = c.continent
+;

--- a/script/calculator/20160531/2400_materialize_dpps_change_interpreters.sql
+++ b/script/calculator/20160531/2400_materialize_dpps_change_interpreters.sql
@@ -1,0 +1,23 @@
+delete from dpps_sums_continent_category;
+insert into dpps_sums_continent_category
+select * from i_dpps_sums_continent_category;
+
+delete from dpps_sums_continent_category_reason;
+insert into dpps_sums_continent_category_reason
+select * from i_dpps_sums_continent_category_reason;
+
+delete from dpps_sums_region_category;
+insert into dpps_sums_region_category
+select * from i_dpps_sums_region_category;
+
+delete from dpps_sums_region_category_reason;
+insert into dpps_sums_region_category_reason
+select * from i_dpps_sums_region_category_reason;
+
+delete from dpps_sums_country_category;
+insert into dpps_sums_country_category
+select * from i_dpps_sums_country_category;
+
+delete from dpps_sums_country_category_reason;
+insert into dpps_sums_country_category_reason
+select * from i_dpps_sums_country_category_reason;

--- a/script/calculator/20160531/2500_add_change_interpreters.sql
+++ b/script/calculator/20160531/2500_add_change_interpreters.sql
@@ -1,0 +1,111 @@
+-- Completely unnested changes.
+drop view if exists changes_expanded CASCADE;
+CREATE VIEW changes_expanded AS
+  SELECT DISTINCT
+    a.analysis_name,
+    a.analysis_year,
+    ch.reason_change,
+    CASE
+      WHEN ne.reason_change is null THEN ch.reason_change
+      WHEN ne.reason_change = '-' AND ne.age >= 10 THEN 'DD'
+      ELSE ne.reason_change
+    END adjusted_reason_change,
+    ch.country,
+    ch.replaced_stratum,
+    ch.new_stratum
+  FROM (
+    SELECT
+      nc.analysis_name,
+      nc.analysis_year,
+      nc.reason_change,
+      nc.country,
+      rc.replaced_stratum,
+      nc.new_stratum
+    FROM (
+      SELECT 
+        id, analysis_name, analysis_year, reason_change, country,
+        trim(unnest(regexp_split_to_array(new_strata, ','))) as new_stratum
+      FROM changes
+    ) nc
+    LEFT JOIN (
+      SELECT
+        id, analysis_name, analysis_year, reason_change, country,
+        new_strata,
+        trim(unnest(regexp_split_to_array(replaced_strata, ','))) as replaced_stratum
+      FROM changes
+    ) rc ON nc.id = rc.id and nc.new_stratum = ANY((regexp_split_to_array(rc.new_strata, ',')))
+    UNION
+    SELECT
+      analysis_name,
+      analysis_year,
+      reason_change,
+      country,
+      trim(unnest(regexp_split_to_array(replaced_strata, ','))) as replaced_stratum,
+      '-'
+    FROM changes
+    WHERE
+      new_strata = '-' OR new_strata IS NULL
+  ) ch
+  JOIN analyses a ON a.analysis_name = ch.analysis_name
+  LEFT JOIN estimate_factors_analyses_categorized_for_add ne ON ne.analysis_name = ch.analysis_name
+    AND ne.analysis_year = a.analysis_year
+    AND ne.input_zone_id = ch.new_stratum;
+
+-- Replaced strata per analysis
+DROP VIEW IF EXISTS ioc_add_replaced_base CASCADE;
+CREATE VIEW ioc_add_replaced_base AS
+  SELECT
+    e.analysis_name,
+    e.analysis_year,
+    e.continent,
+    e.region,
+    e.country,
+    e.input_zone_id,
+    e.category,
+    c.adjusted_reason_change reason_change,
+    e.best_estimate as population_estimate,
+    e.best_population_variance as population_variance,
+    e.population_lower_confidence_limit,
+    e.population_upper_confidence_limit
+  FROM (
+    SELECT DISTINCT
+      analysis_name,
+      analysis_year,
+      replaced_stratum,
+      adjusted_reason_change
+    FROM changes_expanded
+  ) c
+  JOIN analyses a ON c.analysis_name = a.analysis_name and c.analysis_year = a.analysis_year
+  JOIN estimate_factors_analyses_categorized_for_add e ON e.analysis_name = c.analysis_name
+    AND e.analysis_year = a.comparison_year
+    AND e.input_zone_id = c.replaced_stratum;
+
+-- New strata per analysis
+DROP VIEW IF EXISTS ioc_add_new_base CASCADE;
+CREATE VIEW ioc_add_new_base AS
+  SELECT
+    e.analysis_name,
+    e.analysis_year,
+    e.continent,
+    e.region,
+    e.country,
+    e.input_zone_id,
+    e.category,
+    c.adjusted_reason_change reason_change,
+    e.best_estimate as population_estimate,
+    e.best_population_variance as population_variance,
+    e.population_lower_confidence_limit,
+    e.population_upper_confidence_limit
+  FROM (
+    SELECT DISTINCT
+      analysis_name,
+      analysis_year,
+      new_stratum,
+      adjusted_reason_change
+    FROM changes_expanded
+  ) c
+  JOIN analyses a ON c.analysis_name = a.analysis_name and c.analysis_year = a.analysis_year
+  JOIN estimate_factors_analyses_categorized_for_add e ON e.analysis_name = c.analysis_name
+    AND e.analysis_year = a.analysis_year
+    AND e.input_zone_id = c.new_stratum;
+

--- a/script/calculator/20160531/2600_country_change_interpreters_add.sql
+++ b/script/calculator/20160531/2600_country_change_interpreters_add.sql
@@ -1,0 +1,151 @@
+-- Country change interpeters
+
+-- Standard base views
+
+DROP VIEW IF EXISTS ioc_add_replaced_countries CASCADE;
+CREATE VIEW ioc_add_replaced_countries AS
+  SELECT
+    a.analysis_name,
+    a.analysis_year,
+    old.continent,
+    old.region,
+    old.country,
+    old.reason_change,
+    -1*sum(old.estimate) estimate,
+    sum(old.population_variance) population_variance,
+    -1*sum(old.guess_min) guess_min,
+    -1*sum(old.guess_max) guess_max
+  FROM
+    analyses a
+  JOIN (
+    SELECT
+      e.analysis_name,
+      e.analysis_year,
+      e.continent,
+      e.region,
+      e.country,
+      e.reason_change,
+      sum(e.population_estimate) estimate,
+      sum(e.population_variance) population_variance,
+      sum(e.population_lower_confidence_limit) guess_min,
+      sum(e.population_upper_confidence_limit) guess_max
+    FROM ioc_add_replaced_base e
+    WHERE category <> 'C'
+    GROUP BY e.analysis_name, e.analysis_year, e.continent, e.region, e.country, e.reason_change
+    UNION
+    SELECT
+      e.analysis_name,
+      e.analysis_year,
+      e.continent,
+      e.region,
+      e.country,
+      e.reason_change,
+      sum(e.population_estimate) estimate,
+      0 AS population_variance,
+      sum(e.population_lower_confidence_limit) + 1.96*sqrt(sum(e.population_variance)) AS guess_min,
+      sum(e.population_upper_confidence_limit) + 1.96*sqrt(sum(e.population_variance)) AS guess_max
+    FROM ioc_add_replaced_base e
+    WHERE category = 'C'
+    GROUP BY e.analysis_name, e.analysis_year, e.continent, e.region, e.country, e.reason_change
+  ) old ON old.analysis_name = a.analysis_name
+    AND old.analysis_year = a.comparison_year
+  GROUP BY a.analysis_name, a.analysis_year, old.continent, old.region, old.country, old.reason_change;
+
+DROP VIEW IF EXISTS ioc_add_new_countries CASCADE;
+CREATE OR REPLACE VIEW ioc_add_new_countries AS
+  SELECT
+    a.analysis_name,
+    a.analysis_year,
+    new.continent,
+    new.region,
+    new.country,
+    new.reason_change,
+    sum(new.estimate) estimate,
+    sum(new.population_variance) population_variance,
+    sum(new.guess_min) guess_min,
+    sum(new.guess_max) guess_max
+  FROM
+    analyses a
+  JOIN (
+    SELECT
+      e.analysis_name,
+      e.analysis_year,
+      e.continent,
+      e.region,
+      e.country,
+      e.reason_change,
+      sum(e.population_estimate) estimate,
+      sum(e.population_variance) population_variance,
+      sum(e.population_lower_confidence_limit) guess_min,
+      sum(e.population_upper_confidence_limit) guess_max
+    FROM ioc_add_new_base e
+    WHERE category <> 'C'
+    GROUP BY e.analysis_name, e.analysis_year, e.continent, e.region, e.country, e.reason_change
+    UNION
+    SELECT
+      e.analysis_name,
+      e.analysis_year,
+      e.continent,
+      e.region,
+      e.country,
+      e.reason_change,
+      sum(e.population_estimate) estimate,
+      0 AS population_variance,
+      sum(e.population_lower_confidence_limit) + 1.96*sqrt(sum(e.population_variance)) AS guess_min,
+      sum(e.population_upper_confidence_limit) + 1.96*sqrt(sum(e.population_variance)) AS guess_max
+    FROM ioc_add_new_base e
+    WHERE category = 'C'
+    GROUP BY e.analysis_name, e.analysis_year, e.continent, e.region, e.country, e.reason_change
+  ) new ON new.analysis_name = a.analysis_name
+    AND new.analysis_year = a.analysis_year
+  GROUP BY a.analysis_name, a.analysis_year, new.continent, new.region, new.country, new.reason_change;
+
+-- Calculated views
+
+drop view if exists i_add_sums_country_category_reason cascade;
+create view i_add_sums_country_category_reason as
+  SELECT 
+    analysis_name,
+    analysis_year,
+    continent,
+    region,
+    country,
+    reason_change,
+    sum(estimate) estimate,
+    1.96*sqrt(sum(population_variance)) confidence,
+    sum(guess_min) guess_min,
+    sum(guess_max) guess_max,
+    sum(population_variance) meta_population_variance
+  FROM (
+    SELECT * FROM ioc_add_new_countries i JOIN cause_of_changes c ON i.reason_change = c.code
+  UNION ALL
+    SELECT * FROM ioc_add_replaced_countries i JOIN cause_of_changes c ON i.reason_change = c.code
+  ) x
+  GROUP BY analysis_name, analysis_year, continent, region, country, reason_change
+  ORDER BY analysis_name, analysis_year, continent, region, country, reason_change;
+
+--- Statify the reason base query; it's too slow to run in realtime
+drop table if exists add_sums_country_category_reason cascade;
+create table add_sums_country_category_reason as select * from i_add_sums_country_category_reason;
+
+--- Totals for base query, req'd due to confidence column
+
+drop view if exists i_add_totals_country_category_reason cascade;
+create view i_add_totals_country_category_reason as
+  SELECT
+    analysis_name,
+    analysis_year,
+    continent,
+    region,
+    country,
+    sum(estimate) estimate,
+    1.96*sqrt(sum(meta_population_variance)) confidence,
+    sum(guess_min) guess_min,
+    sum(guess_max) guess_max
+  FROM add_sums_country_category_reason
+  GROUP BY analysis_name, analysis_year, continent, region, country
+  ORDER BY analysis_name, analysis_year, continent, region, country;
+
+drop table if exists add_totals_country_category_reason cascade;
+create table add_totals_country_category_reason as select * from i_add_totals_country_category_reason;
+

--- a/script/calculator/20160531/2700_regional_change_interpreters_add.sql
+++ b/script/calculator/20160531/2700_regional_change_interpreters_add.sql
@@ -1,0 +1,143 @@
+-- Regional change interpeters
+
+-- Standard base views
+
+DROP VIEW IF EXISTS ioc_add_replaced_regions CASCADE;
+CREATE VIEW ioc_add_replaced_regions AS
+  SELECT
+    a.analysis_name,
+    a.analysis_year,
+    old.continent,
+    old.region,
+    old.reason_change,
+    -1*sum(old.estimate) estimate,
+    sum(old.population_variance) population_variance,
+    -1*sum(old.guess_min) guess_min,
+    -1*sum(old.guess_max) guess_max
+  FROM
+    analyses a
+  JOIN (
+    SELECT
+      e.analysis_name,
+      e.analysis_year,
+      e.continent,
+      e.region,
+      e.reason_change,
+      sum(e.population_estimate) estimate,
+      sum(e.population_variance) population_variance,
+      sum(e.population_lower_confidence_limit) guess_min,
+      sum(e.population_upper_confidence_limit) guess_max
+    FROM ioc_add_replaced_base e
+    WHERE category <> 'C'
+    GROUP BY e.analysis_name, e.analysis_year, e.continent, e.region, e.reason_change
+    UNION
+    SELECT
+      e.analysis_name,
+      e.analysis_year,
+      e.continent,
+      e.region,
+      e.reason_change,
+      sum(e.population_estimate) estimate,
+      0 AS population_variance,
+      sum(e.population_lower_confidence_limit) + 1.96*sqrt(sum(e.population_variance)) AS guess_min,
+      sum(e.population_upper_confidence_limit) + 1.96*sqrt(sum(e.population_variance)) AS guess_max
+    FROM ioc_add_replaced_base e
+    WHERE category = 'C'
+    GROUP BY e.analysis_name, e.analysis_year, e.continent, e.region, e.reason_change
+  ) old ON old.analysis_name = a.analysis_name
+    AND old.analysis_year = a.comparison_year
+  GROUP BY a.analysis_name, a.analysis_year, old.continent, old.region, old.reason_change;
+
+DROP VIEW IF EXISTS ioc_add_new_regions CASCADE;
+CREATE OR REPLACE VIEW ioc_add_new_regions AS
+  SELECT
+    a.analysis_name,
+    a.analysis_year,
+    new.continent,
+    new.region,
+    new.reason_change,
+    sum(new.estimate) estimate,
+    sum(new.population_variance) population_variance,
+    sum(new.guess_min) guess_min,
+    sum(new.guess_max) guess_max
+  FROM
+    analyses a
+  JOIN (
+    SELECT
+      e.analysis_name,
+      e.analysis_year,
+      e.continent,
+      e.region,
+      e.reason_change,
+      sum(e.population_estimate) estimate,
+      sum(e.population_variance) population_variance,
+      sum(e.population_lower_confidence_limit) guess_min,
+      sum(e.population_upper_confidence_limit) guess_max
+    FROM ioc_add_new_base e
+    WHERE category <> 'C'
+    GROUP BY e.analysis_name, e.analysis_year, e.continent, e.region, e.reason_change
+    UNION
+    SELECT
+      e.analysis_name,
+      e.analysis_year,
+      e.continent,
+      e.region,
+      e.reason_change,
+      sum(e.population_estimate) estimate,
+      0 AS population_variance,
+      sum(e.population_lower_confidence_limit) + 1.96*sqrt(sum(e.population_variance)) AS guess_min,
+      sum(e.population_upper_confidence_limit) + 1.96*sqrt(sum(e.population_variance)) AS guess_max
+    FROM ioc_add_new_base e
+    WHERE category = 'C'
+    GROUP BY e.analysis_name, e.analysis_year, e.continent, e.region, e.reason_change
+  ) new ON new.analysis_name = a.analysis_name
+    AND new.analysis_year = a.analysis_year
+  GROUP BY a.analysis_name, a.analysis_year, new.continent, new.region, new.reason_change;
+
+-- Calculated views
+
+drop view if exists i_add_sums_region_category_reason cascade;
+create view i_add_sums_region_category_reason as
+  SELECT 
+    analysis_name,
+    analysis_year,
+    continent,
+    region,
+    reason_change,
+    sum(estimate) estimate,
+    1.96*sqrt(sum(population_variance)) confidence,
+    sum(guess_min) guess_min,
+    sum(guess_max) guess_max,
+    sum(population_variance) meta_population_variance
+  FROM (
+    SELECT * FROM ioc_add_new_regions i JOIN cause_of_changes c ON i.reason_change = c.code
+  UNION ALL
+    SELECT * FROM ioc_add_replaced_regions i JOIN cause_of_changes c ON i.reason_change = c.code
+  ) x
+  GROUP BY analysis_name, analysis_year, continent, region, reason_change
+  ORDER BY analysis_name, analysis_year, continent, region, reason_change;
+
+--- Statify the reason base query; it's too slow to run in realtime
+drop table if exists add_sums_region_category_reason cascade;
+create table add_sums_region_category_reason as select * from i_add_sums_region_category_reason;
+
+--- Totals for base query, req'd due to confidence column
+
+drop view if exists i_add_totals_region_category_reason cascade;
+create view i_add_totals_region_category_reason as
+  SELECT
+    analysis_name,
+    analysis_year,
+    continent,
+    region,
+    sum(estimate) estimate,
+    1.96*sqrt(sum(meta_population_variance)) confidence,
+    sum(guess_min) guess_min,
+    sum(guess_max) guess_max
+  FROM add_sums_region_category_reason
+  GROUP BY analysis_name, analysis_year, continent, region
+  ORDER BY analysis_name, analysis_year, continent, region;
+
+drop table if exists add_totals_region_category_reason cascade;
+create table add_totals_region_category_reason as select * from i_add_totals_region_category_reason;
+

--- a/script/calculator/20160531/2800_continental_change_interpreters_add.sql
+++ b/script/calculator/20160531/2800_continental_change_interpreters_add.sql
@@ -1,0 +1,135 @@
+-- Continental change interpeters
+
+-- Standard base queries
+
+DROP VIEW IF EXISTS ioc_add_replaced_continents CASCADE;
+CREATE VIEW ioc_add_replaced_continents AS
+  SELECT
+    a.analysis_name,
+    a.analysis_year,
+    old.continent,
+    old.reason_change,
+    -1*sum(old.estimate) estimate,
+    sum(old.population_variance) population_variance,
+    -1*sum(old.guess_min) guess_min,
+    -1*sum(old.guess_max) guess_max
+  FROM
+    analyses a
+  JOIN (
+    SELECT
+      e.analysis_name,
+      e.analysis_year,
+      e.continent,
+      e.reason_change,
+      sum(e.population_estimate) estimate,
+      sum(e.population_variance) population_variance,
+      sum(e.population_lower_confidence_limit) guess_min,
+      sum(e.population_upper_confidence_limit) guess_max
+    FROM ioc_add_replaced_base e
+    WHERE category <> 'C'
+    GROUP BY e.analysis_name, e.analysis_year, e.continent, e.reason_change
+    UNION
+    SELECT
+      e.analysis_name,
+      e.analysis_year,
+      e.continent,
+      e.reason_change,
+      sum(e.population_estimate) estimate,
+      0 AS population_variance,
+      sum(e.population_lower_confidence_limit) + 1.96*sqrt(sum(e.population_variance)) AS guess_min,
+      sum(e.population_upper_confidence_limit) + 1.96*sqrt(sum(e.population_variance)) AS guess_max
+    FROM ioc_add_replaced_base e
+    WHERE category = 'C'
+    GROUP BY e.analysis_name, e.analysis_year, e.continent, e.reason_change
+  ) old ON old.analysis_name = a.analysis_name
+    AND old.analysis_year = a.comparison_year
+  GROUP BY a.analysis_name, a.analysis_year, old.continent, old.reason_change;
+
+DROP VIEW IF EXISTS ioc_add_new_continents CASCADE;
+CREATE OR REPLACE VIEW ioc_add_new_continents AS
+  SELECT
+    a.analysis_name,
+    a.analysis_year,
+    new.continent,
+    new.reason_change,
+    sum(new.estimate) estimate,
+    sum(new.population_variance) population_variance,
+    sum(new.guess_min) guess_min,
+    sum(new.guess_max) guess_max
+  FROM
+    analyses a
+  JOIN (
+    SELECT
+      e.analysis_name,
+      e.analysis_year,
+      e.continent,
+      e.reason_change,
+      sum(e.population_estimate) estimate,
+      sum(e.population_variance) population_variance,
+      sum(e.population_lower_confidence_limit) guess_min,
+      sum(e.population_upper_confidence_limit) guess_max
+    FROM ioc_add_new_base e
+    WHERE category <> 'C'
+    GROUP BY e.analysis_name, e.analysis_year, e.continent, e.reason_change
+    UNION
+    SELECT
+      e.analysis_name,
+      e.analysis_year,
+      e.continent,
+      e.reason_change,
+      sum(e.population_estimate) estimate,
+      0 AS population_variance,
+      sum(e.population_lower_confidence_limit) + 1.96*sqrt(sum(e.population_variance)) AS guess_min,
+      sum(e.population_upper_confidence_limit) + 1.96*sqrt(sum(e.population_variance)) AS guess_max
+    FROM ioc_add_new_base e
+    WHERE category = 'C'
+    GROUP BY e.analysis_name, e.analysis_year, e.continent, e.reason_change
+  ) new ON new.analysis_name = a.analysis_name
+    AND new.analysis_year = a.analysis_year
+  GROUP BY a.analysis_name, a.analysis_year, new.continent, new.reason_change;
+
+-- Calculated views
+
+drop view if exists i_add_sums_continent_category_reason cascade;
+create view i_add_sums_continent_category_reason as
+  SELECT 
+    analysis_name,
+    analysis_year,
+    continent,
+    reason_change,
+    sum(estimate) estimate,
+    1.96*sqrt(sum(population_variance)) confidence,
+    sum(guess_min) guess_min,
+    sum(guess_max) guess_max,
+    sum(population_variance) meta_population_variance
+  FROM (
+    SELECT * FROM ioc_add_new_continents i JOIN cause_of_changes c ON i.reason_change = c.code
+  UNION ALL
+    SELECT * FROM ioc_add_replaced_continents i JOIN cause_of_changes c ON i.reason_change = c.code
+  ) x
+  GROUP BY analysis_name, analysis_year, continent, reason_change
+  ORDER BY analysis_name, analysis_year, continent, reason_change;
+
+--- Statify the reason base query; it's too slow to run in realtime
+drop table if exists add_sums_continent_category_reason cascade;
+create table add_sums_continent_category_reason as select * from i_add_sums_continent_category_reason;
+
+--- Totals for base query, req'd due to confidence column
+
+drop view if exists i_add_totals_continent_category_reason cascade;
+create view i_add_totals_continent_category_reason as
+  SELECT
+    analysis_name,
+    analysis_year,
+    continent,
+    sum(estimate) estimate,
+    1.96*sqrt(sum(meta_population_variance)) confidence,
+    sum(guess_min) guess_min,
+    sum(guess_max) guess_max
+  FROM add_sums_continent_category_reason
+  GROUP BY analysis_name, analysis_year, continent
+  ORDER BY analysis_name, analysis_year, continent;
+
+drop table if exists add_totals_continent_category_reason cascade;
+create table add_totals_continent_category_reason as select * from i_add_totals_continent_category_reason;
+

--- a/script/calculator/20160531/3100_country_range_support.sql
+++ b/script/calculator/20160531/3100_country_range_support.sql
@@ -1,0 +1,55 @@
+DROP VIEW IF EXISTS country_range_by_category CASCADE;
+CREATE VIEW country_range_by_category AS
+  SELECT
+	  a.region,
+	  a.country,
+    a.category,
+    a.analysis_year,
+    a.analysis_name,
+    a."AREA" as "ASSESSED_RANGE",
+    a."AREA" / rt.range_area * 100 as "CATEGORY_PERCENT_RANGE_ASSESSED",
+    rt.range_area as "RANGE_AREA"
+  FROM (
+    SELECT
+      category,
+      region,
+      country,
+      analysis_year,
+      analysis_name,
+      sum(area_sqkm) as "AREA"
+    FROM
+      survey_range_intersection_metrics sm
+    GROUP BY category, region, country, analysis_year, analysis_name
+  ) a
+  JOIN (
+    SELECT
+      country,
+      sum(area_sqkm) as range_area
+    FROM country_range_metrics
+    GROUP BY country
+  ) rt ON rt.country = a.country
+  ORDER BY country, category;
+
+DROP VIEW IF EXISTS country_range_totals CASCADE;
+CREATE VIEW country_range_totals AS
+  SELECT
+	  a.region,
+    a.country,
+    a.analysis_year,
+    a.analysis_name,
+    sum("ASSESSED_RANGE") as "ASSESSED_RANGE",
+    sum("CATEGORY_PERCENT_RANGE_ASSESSED") as "CATEGORY_PERCENT_RANGE_ASSESSED",
+    "RANGE_AREA"
+  FROM
+    country_range_by_category a
+  GROUP BY region, country, analysis_year, analysis_name, "RANGE_AREA"
+  ORDER BY region, country, analysis_year, analysis_name, "RANGE_AREA";
+
+DROP VIEW IF EXISTS estimate_locator_areas CASCADE;
+CREATE VIEW estimate_locator_areas AS SELECT estimate_locator_with_geometry.input_zone_id,
+    estimate_locator_with_geometry.analysis_name,
+    estimate_locator_with_geometry.analysis_year,
+    sum(st_area(estimate_locator_with_geometry.geom::geography, true)) / 1000000::double precision AS area_sqkm
+   FROM estimate_locator_with_geometry
+  GROUP BY estimate_locator_with_geometry.input_zone_id, estimate_locator_with_geometry.analysis_name, estimate_locator_with_geometry.analysis_year
+  ORDER BY estimate_locator_with_geometry.input_zone_id, estimate_locator_with_geometry.analysis_name, estimate_locator_with_geometry.analysis_year;

--- a/script/calculator/20160531/4000_input_zone_exporter_view.sql
+++ b/script/calculator/20160531/4000_input_zone_exporter_view.sql
@@ -1,0 +1,43 @@
+DROP VIEW IF EXISTS input_zone_export;
+CREATE VIEW input_zone_export AS
+ SELECT
+    l.analysis_name as analysis,
+    l.analysis_year as ayear,
+    l.continent,
+    l.region,
+    l.country,
+    l.replacement_name as inpzone,
+    l.site_name as site,
+    l.stratum_name as stratum,
+    l.input_zone_id as strcode,
+    l.estimate_type as est_type,
+    l.category,
+    l.completion_year as year,
+    l.reason_change as rc,
+    l.citation as full_cit,
+    l.short_citation as short_cit,
+    l.population_estimate as estimate,
+    l.population_variance as variance,
+    l.population_standard_error as std_err,
+    l.population_confidence_interval as ci,
+    l.population_lower_confidence_limit as lcl,
+    l.population_upper_confidence_limit as ucl,
+    l.lcl95 as lcl95,
+    l.quality_level as quality,
+    l.actually_seen as seen,
+    l.stratum_area as area_rep,
+    ST_Area(g.geom::geography,true)/1000000 as area_calc,
+    g.id as sgid
+   FROM estimate_locator l
+     JOIN estimate_factors f ON l.input_zone_id = f.input_zone_id
+     JOIN survey_geometries g ON f.survey_geometry_id = g.id
+   ORDER BY
+    analysis_name,
+    analysis_year,
+    continent,
+    region,
+    country,
+    inpzone,
+    site,
+    stratum
+;

--- a/script/calculator/20160531/5000_appendix_2.sql
+++ b/script/calculator/20160531/5000_appendix_2.sql
@@ -1,0 +1,48 @@
+DROP VIEW IF EXISTS appendix_2_add CASCADE;
+CREATE OR REPLACE VIEW appendix_2_add AS
+  SELECT
+    analysis_name,
+    analysis_year,
+    region,
+    country,
+    replacement_name,
+    estimate_type,
+    estimate,
+    confidence
+  FROM (
+    SELECT
+      e.analysis_name,
+      e.analysis_year,
+      e.continent,
+      e.region,
+      e.country,
+      l.sort_key,
+      l.replacement_name,
+      l.estimate_type,
+      sum(e.population_estimate) estimate,
+      1.96*sqrt(sum(e.population_variance)) confidence
+    FROM ioc_add_new_base e
+    JOIN estimate_locator l ON l.analysis_name = e.analysis_name AND l.analysis_year = e.analysis_year
+      AND l.input_zone_id = e.input_zone_id
+    WHERE e.reason_change = 'RS'
+    GROUP BY e.analysis_name, e.analysis_year, e.continent, e.region, e.country, l.replacement_name, l.estimate_type, l.sort_key
+    UNION
+    SELECT
+      e.analysis_name,
+      e.analysis_year,
+      e.continent,
+      e.region,
+      e.country,
+      l.sort_key,
+      l.replacement_name,
+      l.estimate_type,
+      sum(e.population_estimate) estimate,
+      1.96*sqrt(sum(e.population_variance)) confidence
+    FROM ioc_add_replaced_base e
+    JOIN estimate_locator l ON l.analysis_name = e.analysis_name AND l.analysis_year = e.analysis_year
+      AND l.input_zone_id = e.input_zone_id
+    WHERE e.reason_change = 'RS'
+    GROUP BY e.analysis_name, e.analysis_year, e.continent, e.region, e.country, l.replacement_name, l.estimate_type, l.sort_key
+  ) i
+  ORDER BY analysis_name, region, country, sort_key, replacement_name, analysis_year;
+


### PR DESCRIPTION
For category C, the guess max calculation now incorporates
the confidence level, and also uses the given min/max values
instead of the estimate value, when available. This change
required a bit of a ground-up change in the way ADD values are
stored, calculated, and queried.

New calculator includes changes to the main ADD estimate table
to include appropriate column information, summary and totals
tables for each hierarchical level (country, region, continent)
and a revamp of the cause of changes tables to properly incorporate
the new guesses column.

The queries in the ADD helper class has been updated to use the
new tables, and moved the country stats query to the helper
class.

Important to note is that estimates_...reasons_for_add is gone,
which directly affects the new Appendix II calculations. This
query has been replaced by one that is compatible with the new
ADD cause of change layout.

Also, optimized cause of change queries to build a bit faster
and fixed an issue with modeled extrapolations where some could
be miscategorized.

Finally, fixed an issue with sql reader where certain comments
could cause a script to fail.

See #556
See #550
See #527