### PR TITLE
Change default tile URL to OpenStreetMap

### DIFF
--- a/config/initializers/leaflet.rb
+++ b/config/initializers/leaflet.rb
@@ -1,3 +1,4 @@
-Leaflet.tile_layer ='http://otile2.mqcdn.com/tiles/1.0.0/osm/{z}/{x}/{y}.png'
+Leaflet.tile_layer ='http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'
+Leaflet.subdomains = ['a', 'b', 'c']
 Leaflet.attribution = "AfESG"
 Leaflet.max_zoom = 18


### PR DESCRIPTION
This is a different tile source than the MapQuest tiles previously
used by default. If we want MapQuest back, we can get an API key
for it.